### PR TITLE
Fix removal of obsolete area switches

### DIFF
--- a/custom_components/mammotion/switch.py
+++ b/custom_components/mammotion/switch.py
@@ -375,7 +375,7 @@ def async_add_area_entities(
             )
             added_areas.add(area_id)
 
-    old_areas = set(areas) - added_areas
+    old_areas = added_areas - set(areas)
     if old_areas:
         async_remove_entities(coordinator, old_areas)
         for area in old_areas:


### PR DESCRIPTION
## Summary
- correctly remove stale area switches when mower areas disappear

## Testing
- `python -m py_compile custom_components/mammotion/switch.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689614e346148322893385262a404fd5