### PR TITLE
Add map camera for mower mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This integration allows you to control and monitor Mammotion products, e.g robot
 - Start a mow based on configuration
 - Start an existing scheduled task/s
 - More features being added all the time!
+- Render the mower's path as a map camera for use with front-end map cards
 
 ## Prerequisites 📋
 > [!WARNING]
@@ -56,6 +57,10 @@ This integration is not available in the default HACS store. You will need to ad
 See the wiki for how to [get started](https://github.com/mikey0000/Mammotion-HA/wiki/Getting-Started)
 
 Once the integration is set up, you can control and monitor your Mammotion mower using Home Assistant. 🎉
+
+### Map display
+
+This integration creates a `camera` entity that draws the mower's path. You can display it using the [Lovelace Xiaomi Vacuum Map card](https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card) by pointing the card's `camera_entity` to the map camera.
 
 ## Troubleshooting 🔧
 

--- a/custom_components/mammotion/icons.json
+++ b/custom_components/mammotion/icons.json
@@ -34,6 +34,11 @@
         "default": "mdi:map-marker-remove"
       }
     },
+    "camera": {
+      "map_camera": {
+        "default": "mdi:map"
+      }
+    },
     "sensor": {
       "gps_stars": {
         "default": "mdi:satellite-uplink"

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -151,6 +151,11 @@
         "name": "Clear maps and area names"
       }
     },
+    "camera": {
+      "map_camera": {
+        "name": "Map"
+      }
+    },
     "switch": {
       "area": {
         "name": "Area {name}"

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -164,6 +164,11 @@
         "name": "Clear maps and area names"
       }
     },
+    "camera": {
+      "map_camera": {
+        "name": "Map"
+      }
+    },
     "switch": {
       "area": {
         "name": "Area {name}"


### PR DESCRIPTION
## Summary
- add map camera entity that renders mower path using map data
- provide translations and icon for the new camera entity
- document map camera usage and use Python 3.11-compatible typing
- ensure map coordinator exposes full device state to prevent missing firmware info

## Testing
- `pre-commit run --files custom_components/mammotion/camera.py custom_components/mammotion/icons.json custom_components/mammotion/strings.json custom_components/mammotion/translations/en.json custom_components/mammotion/__init__.py custom_components/mammotion/coordinator.py README.md`
- `pre-commit run --files custom_components/mammotion/coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_689789f43a9c8322a499fdfb8cc36589