### PR TITLE
Add map camera for mower mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This integration allows you to control and monitor Mammotion products, e.g robot
 - Start a mow based on configuration
 - Start an existing scheduled task/s
 - More features being added all the time!
+- Render the mower's path as a map camera for use with front-end map cards
 
 ## Prerequisites 📋
 > [!WARNING]
@@ -56,6 +57,10 @@ This integration is not available in the default HACS store. You will need to ad
 See the wiki for how to [get started](https://github.com/mikey0000/Mammotion-HA/wiki/Getting-Started)
 
 Once the integration is set up, you can control and monitor your Mammotion mower using Home Assistant. 🎉
+
+### Map display
+
+This integration creates a `camera` entity that draws the mower's path and a companion `vacuum` entity for compatibility with map cards. When using the [Lovelace Xiaomi Vacuum Map card](https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card), set the card's `entity` to the mower's vacuum entity and `camera_entity` to the map camera.
 
 ## Troubleshooting 🔧
 

--- a/custom_components/mammotion/__init__.py
+++ b/custom_components/mammotion/__init__.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
+from typing import TypeAlias
+
 from aiohttp import ClientConnectorError
 from homeassistant.components import bluetooth
 from homeassistant.components.http import StaticPathConfig
@@ -34,7 +37,6 @@ from .const import (
     CONF_BLE_DEVICES,
     CONF_CONNECT_DATA,
     CONF_DEVICE_DATA,
-    CONF_DEVICE_NAME,
     CONF_MAMMOTION_DATA,
     CONF_REGION_DATA,
     CONF_SESSION_DATA,
@@ -64,12 +66,13 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.CAMERA,
     Platform.UPDATE,
+    Platform.VACUUM,
 ]
 
-type MammotionConfigEntry = ConfigEntry[list[MammotionMowerData]]
+MammotionConfigEntry: TypeAlias = ConfigEntry[list[MammotionMowerData]]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: MammotionConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: MammotionConfigEntry) -> bool:  # noqa: C901
     """Set up Mammotion Luba from a config entry."""
 
     addresses = entry.data.get(CONF_BLE_DEVICES, {})
@@ -107,12 +110,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: MammotionConfigEntry) ->
                     cloud_client.set_http(mammotion_http)
                 await mammotion.initiate_cloud_connection(account, cloud_client)
         except ClientConnectorError as err:
-            raise ConfigEntryNotReady(err)
+            raise ConfigEntryNotReady from err
         except EXPIRED_CREDENTIAL_EXCEPTIONS as exc:
             LOGGER.debug(exc)
             await mammotion.login_and_initiate_cloud(account, password, True)
         except UnretryableException as err:
-            raise ConfigEntryError(err)
+            raise ConfigEntryError from err
 
         if mqtt_client := mammotion.mqtt_list.get(account):
             store_cloud_credentials(hass, entry, mqtt_client.cloud_client)
@@ -187,10 +190,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: MammotionConfigEntry) ->
                         map_coordinator=map_coordinator,
                     )
                 )
-                try:
+                with suppress(Exception):
                     await map_coordinator.async_request_refresh()
-                except:
-                    """Do nothing for now."""
 
     # if not any(mammotion.get_device_by_name(mammotion_device.device.deviceName).preference == ConnectionPreference.WIFI for mammotion_device in mammotion_devices):
     #     for mammotion_device in mammotion_devices:
@@ -326,10 +327,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: MammotionConfigEntry) -
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         for mower in entry.runtime_data:
-            try:
+            with suppress(TimeoutError):
                 await mower.api.remove_device(mower.name)
-            except TimeoutError:
-                """Do nothing as this sometimes occurs with disconnecting BLE."""
     return unload_ok
 
 

--- a/custom_components/mammotion/icons.json
+++ b/custom_components/mammotion/icons.json
@@ -34,6 +34,16 @@
         "default": "mdi:map-marker-remove"
       }
     },
+    "camera": {
+      "map_camera": {
+        "default": "mdi:map"
+      }
+    },
+    "vacuum": {
+      "vacuum": {
+        "default": "mdi:mower"
+      }
+    },
     "sensor": {
       "gps_stars": {
         "default": "mdi:satellite-uplink"

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -151,6 +151,16 @@
         "name": "Clear maps and area names"
       }
     },
+    "camera": {
+      "map_camera": {
+        "name": "Map"
+      }
+    },
+    "vacuum": {
+      "vacuum": {
+        "name": "Vacuum"
+      }
+    },
     "switch": {
       "area": {
         "name": "Area {name}"

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -164,6 +164,16 @@
         "name": "Clear maps and area names"
       }
     },
+    "camera": {
+      "map_camera": {
+        "name": "Map"
+      }
+    },
+    "vacuum": {
+      "vacuum": {
+        "name": "Vacuum"
+      }
+    },
     "switch": {
       "area": {
         "name": "Area {name}"

--- a/custom_components/mammotion/vacuum.py
+++ b/custom_components/mammotion/vacuum.py
@@ -1,0 +1,79 @@
+"""Expose mower as a vacuum entity for map card compatibility."""
+
+from __future__ import annotations
+
+from homeassistant.components.lawn_mower import LawnMowerActivity
+from homeassistant.components.vacuum import (
+    StateVacuumEntity,
+    VacuumActivity,
+    VacuumEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import MammotionConfigEntry
+from .coordinator import MammotionReportUpdateCoordinator
+from .lawn_mower import MammotionLawnMowerEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MammotionConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Mammotion vacuum entities."""
+    mowers = entry.runtime_data
+    entities = [MammotionVacuumEntity(mower.reporting_coordinator) for mower in mowers]
+    async_add_entities(entities)
+
+
+class MammotionVacuumEntity(MammotionLawnMowerEntity, StateVacuumEntity):
+    """Representation of the mower as a vacuum."""
+
+    _attr_supported_features = (
+        VacuumEntityFeature.START
+        | VacuumEntityFeature.PAUSE
+        | VacuumEntityFeature.STOP
+        | VacuumEntityFeature.RETURN_HOME
+    )
+
+    def __init__(self, coordinator: MammotionReportUpdateCoordinator) -> None:
+        """Initialize the vacuum entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.device_name}_vacuum"
+        self._attr_translation_key = "vacuum"
+        self._attr_icon = "mdi:mower"
+
+    @property
+    def activity(self) -> VacuumActivity | None:
+        """Map mower activity to vacuum activity."""
+        mower_activity = super().activity
+        if mower_activity is None:
+            return None
+        if mower_activity == LawnMowerActivity.MOWING:
+            return VacuumActivity.CLEANING
+        if mower_activity == LawnMowerActivity.RETURNING:
+            return VacuumActivity.RETURNING
+        if mower_activity == LawnMowerActivity.PAUSED:
+            return VacuumActivity.PAUSED
+        if mower_activity == LawnMowerActivity.DOCKED:
+            return VacuumActivity.DOCKED
+        if mower_activity == LawnMowerActivity.ERROR:
+            return VacuumActivity.ERROR
+        return VacuumActivity.IDLE
+
+    async def async_start(self) -> None:
+        """Start mowing."""
+        await self.async_start_mowing()
+
+    async def async_stop(self) -> None:
+        """Cancel the current job."""
+        await self.async_cancel()
+
+    async def async_pause(self) -> None:
+        """Pause the mower."""
+        await super().async_pause()
+
+    async def async_return_to_base(self) -> None:
+        """Send mower to the dock."""
+        await self.async_dock()


### PR DESCRIPTION
## Summary
- add map camera entity that renders mower path using map data
- provide translations and icon for the new camera entity
- document map camera usage and use Python 3.11-compatible typing
- ensure map coordinator exposes full device state to prevent missing firmware info
- expose mower as a vacuum entity so third-party map cards can link to it

## Testing
- `poetry run pre-commit run --files custom_components/mammotion/vacuum.py custom_components/mammotion/__init__.py custom_components/mammotion/strings.json custom_components/mammotion/translations/en.json custom_components/mammotion/icons.json README.md`
- `pre-commit run --files custom_components/mammotion/camera.py custom_components/mammotion/icons.json custom_components/mammotion/strings.json custom_components/mammotion/translations/en.json custom_components/mammotion/__init__.py custom_components/mammotion/coordinator.py README.md`
- `pre-commit run --files custom_components/mammotion/coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_689789f43a9c8322a499fdfb8cc36589