### PR TITLE
feat: link-health diagnostics — cloud budget, command timeouts, refresh button

### DIFF
--- a/custom_components/mammotion/button.py
+++ b/custom_components/mammotion/button.py
@@ -110,6 +110,17 @@ BUTTON_SENSORS: tuple[MammotionButtonSensorEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
     ),
     MammotionButtonSensorEntityDescription(
+        # Pull a fresh device report on demand. Useful because this mower dozes
+        # to `ble_rssi: 0` within ~10-13 min of idling, after which every entity
+        # reads its last value and looks healthy; a manual refresh is the
+        # operator-facing equivalent of the `warm_ble_link` step the motion
+        # harness runs before it judges the link. DIAGNOSTIC, not CONFIG: it
+        # reads, it does not change anything on the device.
+        key="refresh_status",
+        press_fn=lambda coordinator: coordinator.async_ensure_fresh_state(),
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MammotionButtonSensorEntityDescription(
         key="resync_rtk_dock",
         press_fn=lambda coordinator: coordinator.async_rtk_dock_location(),
         entity_category=EntityCategory.CONFIG,

--- a/custom_components/mammotion/coordinator.py
+++ b/custom_components/mammotion/coordinator.py
@@ -10,6 +10,7 @@ import json
 import secrets
 import time
 from abc import abstractmethod
+from collections import deque
 from collections.abc import Callable, Mapping
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, cast
@@ -121,6 +122,12 @@ SPINO_INTERVAL = timedelta(weeks=1)
 # the ``map_sync_status`` diagnostic ENUM sensor that surfaces it.
 MAP_SYNC_STATUSES = ("synced", "syncing", "out_of_sync")
 
+#: Rolling window for the command-timeout diagnostic. 24 h deliberately matches
+#: the cloud transport's own `sends_in_window()` window so the two sensors can
+#: be read against each other without mentally rescaling one of them.
+_COMMAND_TIMEOUT_WINDOW_SECONDS = 24 * 60 * 60
+CLOUD_SEND_LIMIT_STATES = ("ok", "rate_limited")
+
 # Cloud response code returned by the stream-subscription endpoint when the
 # device is unreachable ("Device not responding. Please check the network
 # connection").  Treated as a device-offline signal.
@@ -163,6 +170,14 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):
         self.manager: MammotionClient = mammotion
         self._operation_settings = OperationSettings()
         self.update_failures = 0
+        # Monotonic timestamps of CommandTimeoutError raised out of
+        # `async_send_command`, the single funnel every queued command passes
+        # through. Kept as a rolling 24 h window to match the cloud transport's
+        # own `sends_in_window()` accounting, so the two diagnostics can be read
+        # side by side. Monotonic, not wall clock: the window must survive a
+        # clock step, and it resets on restart, which is the honest behaviour
+        # for a counter that only ever lived in memory.
+        self._command_timeouts: deque[float] = deque()
         self._stream_data: Response[StreamSubscriptionResponse] | None = (
             None  # Stream data [Agora]
         )
@@ -486,6 +501,80 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):
             return bool(not handle.availability.mqtt_reported_offline)
         return False
 
+    def _cloud_transport(self) -> Any | None:
+        """Return the connected cloud transport, or the first registered one.
+
+        Two cloud transports can be registered (Aliyun and Mammotion) and only
+        one is normally live, so prefer a connected one and fall back to
+        whichever exists — a rate limit on an idle transport is still worth
+        reporting.
+        """
+        handle = self.manager.mower(self.device_name)
+        if handle is None:
+            return None
+        cloud_types = (TransportType.CLOUD_ALIYUN, TransportType.CLOUD_MAMMOTION)
+        fallback: Any | None = None
+        for t_type in cloud_types:
+            if not handle.has_transport(t_type):
+                continue
+            transport = handle.get_transport(t_type)
+            if transport is None:
+                continue
+            if handle.is_transport_connected(t_type):
+                return transport
+            if fallback is None:
+                fallback = transport
+        return fallback
+
+    @property
+    def cloud_sends_in_window(self) -> int | None:
+        """Cloud sends in the transport's rolling 24 h window, or None.
+
+        Counts every PHYSICAL send including retries, so ACK degradation shows
+        up here as an elevated rate before it shows up as a rate limit. None
+        means no cloud transport is registered, which is not the same as zero.
+        """
+        transport = self._cloud_transport()
+        if transport is None:
+            return None
+        try:
+            return int(transport.sends_in_window())
+        except AttributeError, TypeError, ValueError:
+            return None
+
+    @property
+    def cloud_send_limit_state(self) -> str | None:
+        """`rate_limited` while cloud sends are blocked, else `ok`.
+
+        Covers both sources PyMammotion folds into `is_rate_limited`: a
+        cloud-imposed 429 ban and the self-imposed rolling quota.
+        """
+        transport = self._cloud_transport()
+        if transport is None:
+            return None
+        try:
+            return "rate_limited" if bool(transport.is_rate_limited) else "ok"
+        except AttributeError, TypeError:
+            return None
+
+    def record_command_timeout(self) -> None:
+        """Note a command timeout for the rolling 24 h diagnostic."""
+        self._command_timeouts.append(time.monotonic())
+
+    @property
+    def command_timeouts_in_window(self) -> int:
+        """Command timeouts in the last 24 h.
+
+        ⚠️ Counts timeouts raised out of `async_send_command` only. Commands
+        dispatched by the motion executors in `services.py` do not pass through
+        it, so this is a measure of the INTEGRATION's command health, not of a
+        motion run's. Reads as 0 on a healthy link and resets on restart.
+        """
+        cutoff = time.monotonic() - _COMMAND_TIMEOUT_WINDOW_SECONDS
+        while self._command_timeouts and self._command_timeouts[0] < cutoff:
+            self._command_timeouts.popleft()
+        return len(self._command_timeouts)
+
     @property
     def bluetooth_enabled(self) -> bool:
         """Return whether Bluetooth transport is enabled."""
@@ -746,6 +835,13 @@ class MammotionBaseUpdateCoordinator[DataT](DataUpdateCoordinator[DataT]):
             self.update_failures += 1
             self.last_command_failure_reason = f"{command}:{type(exc).__name__}"
             await self.async_refresh_login(exc)
+        except CommandTimeoutError:
+            # Count it and re-raise UNCHANGED. Callers already handle this --
+            # several catch it and pass -- so swallowing it here to make the
+            # accounting tidier would silently change command behaviour. The
+            # counter is a diagnostic; it must not become a control-flow change.
+            self.record_command_timeout()
+            raise
         except GatewayTimeoutException as ex:
             LOGGER.error(f"Gateway timeout exception: {ex.iot_id}")
             self.update_failures = 0

--- a/custom_components/mammotion/icons.json
+++ b/custom_components/mammotion/icons.json
@@ -41,6 +41,9 @@
       },
       "refresh_cloud_session": {
         "default": "mdi:cloud-refresh"
+      },
+      "refresh_status": {
+        "default": "mdi:refresh"
       }
     },
     "camera": {
@@ -161,6 +164,15 @@
       },
       "zone_hash": {
         "default": "mdi:vector-square"
+      },
+      "cloud_sends_24h": {
+        "default": "mdi:cloud-upload-outline"
+      },
+      "cloud_send_limit": {
+        "default": "mdi:cloud-alert-outline"
+      },
+      "command_timeouts_24h": {
+        "default": "mdi:timer-alert-outline"
       }
     },
     "select": {

--- a/custom_components/mammotion/sensor.py
+++ b/custom_components/mammotion/sensor.py
@@ -50,6 +50,7 @@ from pymammotion.utility.device_type import DeviceType
 from . import MammotionConfigEntry
 from .const import DOMAIN
 from .coordinator import (
+    CLOUD_SEND_LIMIT_STATES,
     MAP_SYNC_STATUSES,
     MammotionBaseUpdateCoordinator,
     MammotionDeviceErrorUpdateCoordinator,
@@ -722,6 +723,35 @@ WORK_SENSOR_TYPES: tuple[MammotionWorkSensorEntityDescription, ...] = (
         options=list(MAP_SYNC_STATUSES),
         native_unit_of_measurement=None,
         value_fn=lambda coordinator, mower_data: coordinator.map_sync_status,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # Link-health diagnostics. These make visible what was previously only at
+    # DEBUG/WARNING log level: how hard we are leaning on the cloud transport,
+    # whether it is currently blocked, and how often commands time out. The
+    # 2026-08-11 session had to infer link degradation from `ble_rssi` plus one
+    # failed run, and a distance-based explanation for it had to be withdrawn --
+    # a counter beats an inference.
+    MammotionWorkSensorEntityDescription(
+        key="cloud_sends_24h",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=None,
+        value_fn=lambda coordinator, mower_data: coordinator.cloud_sends_in_window,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MammotionWorkSensorEntityDescription(
+        key="cloud_send_limit",
+        state_class=None,
+        device_class=SensorDeviceClass.ENUM,
+        options=list(CLOUD_SEND_LIMIT_STATES),
+        native_unit_of_measurement=None,
+        value_fn=lambda coordinator, mower_data: coordinator.cloud_send_limit_state,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    MammotionWorkSensorEntityDescription(
+        key="command_timeouts_24h",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=None,
+        value_fn=lambda coordinator, mower_data: coordinator.command_timeouts_in_window,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     MammotionWorkSensorEntityDescription(

--- a/custom_components/mammotion/strings.json
+++ b/custom_components/mammotion/strings.json
@@ -323,6 +323,19 @@
           "out_of_sync": "Out of sync"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Cloud sends (24 h)"
+      },
+      "cloud_send_limit": {
+        "name": "Cloud send limit",
+        "state": {
+          "ok": "OK",
+          "rate_limited": "Rate limited"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Command timeouts (24 h)"
+      },
       "task_count": {
         "name": "Task count"
       },
@@ -490,6 +503,9 @@
     "button": {
       "start_map_sync": {
         "name": "Sync maps"
+      },
+      "refresh_status": {
+        "name": "Refresh status"
       },
       "resync_rtk_dock": {
         "name": "Sync RTK and dock"

--- a/custom_components/mammotion/translations/cs.json
+++ b/custom_components/mammotion/translations/cs.json
@@ -263,6 +263,19 @@
           "out_of_sync": "Nesynchronizováno"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Odeslání do cloudu (24 h)"
+      },
+      "cloud_send_limit": {
+        "name": "Limit odesílání do cloudu",
+        "state": {
+          "ok": "V pořádku",
+          "rate_limited": "Omezeno"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Vypršení příkazů (24 h)"
+      },
       "mqtt_status": {
         "name": "Stav MQTT",
         "state": {
@@ -481,6 +494,9 @@
       },
       "start_schedule_sync": {
         "name": "Synchronizovat plány"
+      },
+      "refresh_status": {
+        "name": "Obnovit stav"
       },
       "resync_rtk_dock": {
         "name": "Synchronizovat RTK a dok"

--- a/custom_components/mammotion/translations/da.json
+++ b/custom_components/mammotion/translations/da.json
@@ -263,6 +263,19 @@
           "out_of_sync": "Ikke synkroniseret"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Cloud-afsendelser (24 t)"
+      },
+      "cloud_send_limit": {
+        "name": "Cloud-afsendelsesgrænse",
+        "state": {
+          "ok": "OK",
+          "rate_limited": "Begrænset"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Kommando-timeouts (24 t)"
+      },
       "mqtt_status": {
         "name": "MQTT-status",
         "state": {
@@ -481,6 +494,9 @@
       },
       "start_schedule_sync": {
         "name": "Synkroniser tidsplaner"
+      },
+      "refresh_status": {
+        "name": "Opdater status"
       },
       "resync_rtk_dock": {
         "name": "Synkroniser RTK og ladestation"

--- a/custom_components/mammotion/translations/de.json
+++ b/custom_components/mammotion/translations/de.json
@@ -263,6 +263,19 @@
           "out_of_sync": "Nicht synchronisiert"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Cloud-Sendungen (24 Std.)"
+      },
+      "cloud_send_limit": {
+        "name": "Cloud-Sendelimit",
+        "state": {
+          "ok": "OK",
+          "rate_limited": "Limitiert"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Befehls-Zeitüberschreitungen (24 Std.)"
+      },
       "mqtt_status": {
         "name": "MQTT-Status",
         "state": {
@@ -481,6 +494,9 @@
       },
       "start_schedule_sync": {
         "name": "Synchronisiere Zeitpläne"
+      },
+      "refresh_status": {
+        "name": "Status aktualisieren"
       },
       "resync_rtk_dock": {
         "name": "Synchronisiere RTK und Ladestation"

--- a/custom_components/mammotion/translations/en.json
+++ b/custom_components/mammotion/translations/en.json
@@ -275,6 +275,19 @@
           "out_of_sync": "Out of sync"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Cloud sends (24 h)"
+      },
+      "cloud_send_limit": {
+        "name": "Cloud send limit",
+        "state": {
+          "ok": "OK",
+          "rate_limited": "Rate limited"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Command timeouts (24 h)"
+      },
       "task_count": {
         "name": "Task count"
       },
@@ -493,6 +506,9 @@
       },
       "start_schedule_sync": {
         "name": "Synchronize schedules"
+      },
+      "refresh_status": {
+        "name": "Refresh status"
       },
       "resync_rtk_dock": {
         "name": "Sync RTK and dock"

--- a/custom_components/mammotion/translations/fr.json
+++ b/custom_components/mammotion/translations/fr.json
@@ -263,6 +263,19 @@
           "out_of_sync": "Désynchronisée"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Envois cloud (24 h)"
+      },
+      "cloud_send_limit": {
+        "name": "Limite d'envoi cloud",
+        "state": {
+          "ok": "OK",
+          "rate_limited": "Débit limité"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Délais de commande dépassés (24 h)"
+      },
       "mqtt_status": {
         "name": "État MQTT",
         "state": {
@@ -481,6 +494,9 @@
       },
       "start_schedule_sync": {
         "name": "Synchroniser les plannings"
+      },
+      "refresh_status": {
+        "name": "Actualiser l'état"
       },
       "resync_rtk_dock": {
         "name": "Synchroniser RTK et base"

--- a/custom_components/mammotion/translations/hu.json
+++ b/custom_components/mammotion/translations/hu.json
@@ -263,6 +263,19 @@
           "out_of_sync": "Nincs szinkronizálva"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Felhőbe küldések (24 ó)"
+      },
+      "cloud_send_limit": {
+        "name": "Felhő küldési korlát",
+        "state": {
+          "ok": "Rendben",
+          "rate_limited": "Korlátozva"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Parancs-időtúllépések (24 ó)"
+      },
       "mqtt_status": {
         "name": "MQTT állapot",
         "state": {
@@ -481,6 +494,9 @@
       },
       "start_schedule_sync": {
         "name": "Ütemezések szinkronizálása"
+      },
+      "refresh_status": {
+        "name": "Állapot frissítése"
       },
       "resync_rtk_dock": {
         "name": "RTK és dokk szinkronizálása"

--- a/custom_components/mammotion/translations/it.json
+++ b/custom_components/mammotion/translations/it.json
@@ -263,6 +263,19 @@
           "out_of_sync": "Non sincronizzata"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Invii al cloud (24 h)"
+      },
+      "cloud_send_limit": {
+        "name": "Limite invii cloud",
+        "state": {
+          "ok": "OK",
+          "rate_limited": "Limitato"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Timeout comandi (24 h)"
+      },
       "mqtt_status": {
         "name": "Stato MQTT",
         "state": {
@@ -481,6 +494,9 @@
       },
       "start_schedule_sync": {
         "name": "Sincronizza programmi"
+      },
+      "refresh_status": {
+        "name": "Aggiorna stato"
       },
       "resync_rtk_dock": {
         "name": "Sincronizza base e RTK"

--- a/custom_components/mammotion/translations/nl.json
+++ b/custom_components/mammotion/translations/nl.json
@@ -263,6 +263,19 @@
           "out_of_sync": "Niet gesynchroniseerd"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Cloudverzendingen (24 u)"
+      },
+      "cloud_send_limit": {
+        "name": "Cloudverzendlimiet",
+        "state": {
+          "ok": "OK",
+          "rate_limited": "Beperkt"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Commando-time-outs (24 u)"
+      },
       "mqtt_status": {
         "name": "MQTT-status",
         "state": {
@@ -481,6 +494,9 @@
       },
       "start_schedule_sync": {
         "name": "Schema's synchroniseren"
+      },
+      "refresh_status": {
+        "name": "Status vernieuwen"
       },
       "resync_rtk_dock": {
         "name": "Synchroniseer RTK en laadstation"

--- a/custom_components/mammotion/translations/pl.json
+++ b/custom_components/mammotion/translations/pl.json
@@ -263,6 +263,19 @@
           "out_of_sync": "Niezsynchronizowano"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Wysyłki do chmury (24 h)"
+      },
+      "cloud_send_limit": {
+        "name": "Limit wysyłek do chmury",
+        "state": {
+          "ok": "OK",
+          "rate_limited": "Ograniczono"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Przekroczenia czasu poleceń (24 h)"
+      },
       "mqtt_status": {
         "name": "Stan MQTT",
         "state": {
@@ -481,6 +494,9 @@
       },
       "start_schedule_sync": {
         "name": "Synchronizuj harmonogramy"
+      },
+      "refresh_status": {
+        "name": "Odśwież stan"
       },
       "resync_rtk_dock": {
         "name": "Zsynchronizuj RTK i stację ładującą"

--- a/custom_components/mammotion/translations/ro.json
+++ b/custom_components/mammotion/translations/ro.json
@@ -263,6 +263,19 @@
           "out_of_sync": "Nesincronizat"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Trimiteri în cloud (24 h)"
+      },
+      "cloud_send_limit": {
+        "name": "Limită trimiteri cloud",
+        "state": {
+          "ok": "OK",
+          "rate_limited": "Limitat"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Expirări comenzi (24 h)"
+      },
       "mqtt_status": {
         "name": "Stare MQTT",
         "state": {
@@ -481,6 +494,9 @@
       },
       "start_schedule_sync": {
         "name": "Sincronizați programele"
+      },
+      "refresh_status": {
+        "name": "Reîmprospătează starea"
       },
       "resync_rtk_dock": {
         "name": "Sincronizați RTK și docul"

--- a/custom_components/mammotion/translations/sl.json
+++ b/custom_components/mammotion/translations/sl.json
@@ -263,6 +263,19 @@
           "out_of_sync": "Ni sinhronizirano"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Pošiljanja v oblak (24 h)"
+      },
+      "cloud_send_limit": {
+        "name": "Omejitev pošiljanja v oblak",
+        "state": {
+          "ok": "V redu",
+          "rate_limited": "Omejeno"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Potek ukazov (24 h)"
+      },
       "mqtt_status": {
         "name": "Stanje MQTT",
         "state": {
@@ -481,6 +494,9 @@
       },
       "start_schedule_sync": {
         "name": "Sinhronizacija urnikov"
+      },
+      "refresh_status": {
+        "name": "Osveži stanje"
       },
       "resync_rtk_dock": {
         "name": "Sinhronizacija položaja RTK in polnilne postaje"

--- a/custom_components/mammotion/translations/sv.json
+++ b/custom_components/mammotion/translations/sv.json
@@ -263,6 +263,19 @@
           "out_of_sync": "Inte synkroniserad"
         }
       },
+      "cloud_sends_24h": {
+        "name": "Molnsändningar (24 h)"
+      },
+      "cloud_send_limit": {
+        "name": "Gräns för molnsändningar",
+        "state": {
+          "ok": "OK",
+          "rate_limited": "Begränsad"
+        }
+      },
+      "command_timeouts_24h": {
+        "name": "Kommandotimeouter (24 h)"
+      },
       "mqtt_status": {
         "name": "MQTT-status",
         "state": {
@@ -481,6 +494,9 @@
       },
       "start_schedule_sync": {
         "name": "Synkronisera scheman"
+      },
+      "refresh_status": {
+        "name": "Uppdatera status"
       },
       "resync_rtk_dock": {
         "name": "Synkronisera RTK och laddstationen"

--- a/tests/components/mammotion/test_link_health_diagnostics.py
+++ b/tests/components/mammotion/test_link_health_diagnostics.py
@@ -1,0 +1,247 @@
+"""Tests for the link-health diagnostics: cloud budget, command timeouts, refresh.
+
+Adapted from upstream mikey0000/Mammotion-HA PRs #800 and #836. The behaviour
+tests matter more than the entity plumbing: the command-timeout counter sits in
+`async_send_command`, the single funnel every queued command passes through, and
+a diagnostic that quietly swallowed the exception would be a control-flow change
+wearing a sensor's clothes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pymammotion.transport import CommandTimeoutError
+
+from custom_components.mammotion import coordinator as coordinator_module
+from custom_components.mammotion.button import BUTTON_SENSORS
+from custom_components.mammotion.coordinator import (
+    CLOUD_SEND_LIMIT_STATES,
+    MammotionBaseUpdateCoordinator,
+)
+from custom_components.mammotion.sensor import WORK_SENSOR_TYPES
+
+LOCALES = ("cs", "da", "de", "en", "fr", "hu", "it", "nl", "pl", "ro", "sl", "sv")
+NEW_SENSOR_KEYS = ("cloud_sends_24h", "cloud_send_limit", "command_timeouts_24h")
+NEW_BUTTON_KEY = "refresh_status"
+
+
+def _integration_json(name: str) -> dict[str, Any]:
+    root = Path(__file__).resolve().parents[3] / "custom_components" / "mammotion"
+    return json.loads((root / name).read_text(encoding="utf-8"))
+
+
+class _ConcreteCoordinator(MammotionBaseUpdateCoordinator):
+    """Minimal concrete subclass -- the base declares one abstract method."""
+
+    def get_coordinator_data(self, device: Any) -> Any:
+        return device
+
+
+def _bare_coordinator() -> Any:
+    """Build a coordinator carrying only the attributes these properties touch.
+
+    Constructing the real thing needs a HA instance and a config entry; every
+    property under test reads `self.manager`, `self.device_name` and
+    `self._command_timeouts` and nothing else.
+    """
+    coordinator = object.__new__(_ConcreteCoordinator)
+    coordinator._command_timeouts = coordinator_module.deque()  # noqa: SLF001
+    coordinator.device_name = "mower"
+    coordinator.manager = SimpleNamespace(mower=lambda _name: None)
+    return coordinator
+
+
+# ---------------------------------------------------------------- translations
+
+
+def test_new_entities_are_named_in_every_locale() -> None:
+    """A missing name renders as a blank entity, so every locale must carry one."""
+    for filename in ["strings.json", *[f"translations/{loc}.json" for loc in LOCALES]]:
+        doc = _integration_json(filename)
+        buttons = doc.get("entity", {}).get("button", {})
+        sensors = doc.get("entity", {}).get("sensor", {})
+        assert buttons.get(NEW_BUTTON_KEY, {}).get("name"), (
+            f"{filename}: button.{NEW_BUTTON_KEY}"
+        )
+        for key in NEW_SENSOR_KEYS:
+            assert sensors.get(key, {}).get("name"), f"{filename}: sensor.{key}"
+
+
+def test_enum_sensor_states_are_translated_in_every_locale() -> None:
+    """An ENUM sensor with an untranslated state renders the raw slug."""
+    for filename in ["strings.json", *[f"translations/{loc}.json" for loc in LOCALES]]:
+        doc = _integration_json(filename)
+        states = (
+            doc.get("entity", {})
+            .get("sensor", {})
+            .get("cloud_send_limit", {})
+            .get("state", {})
+        )
+        assert set(states) == set(CLOUD_SEND_LIMIT_STATES), filename
+        for value in states.values():
+            assert value, f"{filename}: empty cloud_send_limit state"
+
+
+def test_non_english_locales_are_not_english_placeholders() -> None:
+    """CLAUDE.md forbids copying the English string into the other locales."""
+    english = _integration_json("translations/en.json")["entity"]
+    for loc in (loc for loc in LOCALES if loc != "en"):
+        doc = _integration_json(f"translations/{loc}.json")["entity"]
+        for key in ("cloud_sends_24h", "command_timeouts_24h"):
+            assert doc["sensor"][key]["name"] != english["sensor"][key]["name"], (
+                f"{loc}: sensor.{key} is still the English string"
+            )
+        assert (
+            doc["button"][NEW_BUTTON_KEY]["name"]
+            != english["button"][NEW_BUTTON_KEY]["name"]
+        ), f"{loc}: button.{NEW_BUTTON_KEY} is still the English string"
+
+
+def test_new_entities_have_icons() -> None:
+    """An icon-less diagnostic entity is hard to find in a long entity list."""
+    icons = _integration_json("icons.json")["entity"]
+    assert icons["button"][NEW_BUTTON_KEY]["default"]
+    for key in NEW_SENSOR_KEYS:
+        assert icons["sensor"][key]["default"], key
+
+
+# ------------------------------------------------------------------- wiring
+
+
+def test_the_entities_are_registered() -> None:
+    """Translations without a registered entity are dead weight, and vice versa."""
+    sensor_keys = {d.key for d in WORK_SENSOR_TYPES}
+    assert set(NEW_SENSOR_KEYS) <= sensor_keys
+    assert NEW_BUTTON_KEY in {d.key for d in BUTTON_SENSORS}
+
+
+def test_enum_sensor_declares_its_options() -> None:
+    """Without `options` HA rejects an ENUM sensor's state at runtime."""
+    description = next(d for d in WORK_SENSOR_TYPES if d.key == "cloud_send_limit")
+    assert set(description.options or []) == set(CLOUD_SEND_LIMIT_STATES)
+
+
+# --------------------------------------------------------- timeout accounting
+
+
+def test_command_timeouts_start_at_zero() -> None:
+    """A healthy link reads 0, not unknown."""
+    assert _bare_coordinator().command_timeouts_in_window == 0
+
+
+def test_command_timeouts_accumulate_and_expire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The window is rolling: entries older than 24 h fall out of the count."""
+    coordinator = _bare_coordinator()
+    now = 1_000.0
+    monkeypatch.setattr(coordinator_module.time, "monotonic", lambda: now)
+
+    for _ in range(3):
+        coordinator.record_command_timeout()
+    assert coordinator.command_timeouts_in_window == 3
+
+    now += 23 * 60 * 60  # still inside the window
+    assert coordinator.command_timeouts_in_window == 3
+
+    now += 2 * 60 * 60  # 25 h after the first three
+    coordinator.record_command_timeout()
+    assert coordinator.command_timeouts_in_window == 1
+
+
+@pytest.mark.asyncio
+async def test_a_command_timeout_is_counted_and_STILL_RAISED() -> None:
+    """The counter must not become control flow.
+
+    Callers of `async_send_command` already handle `CommandTimeoutError` -- some
+    catch it and pass. Swallowing it here to make the accounting tidier would
+    silently change what happens when a command times out.
+    """
+    coordinator = _bare_coordinator()
+    coordinator._bluetooth_enabled = True  # noqa: SLF001
+    coordinator.update_failures = 0
+    coordinator.last_command_failure_reason = None
+    coordinator.is_online = lambda: True
+
+    async def _raise(*_args: Any, **_kwargs: Any) -> None:
+        raise CommandTimeoutError("some_field", 3)
+
+    coordinator.manager = SimpleNamespace(
+        get_device_by_name=lambda _n: SimpleNamespace(),
+        send_command_with_args=_raise,
+        mower=lambda _n: None,
+    )
+
+    with pytest.raises(CommandTimeoutError):
+        await coordinator.async_send_command("some_command")
+    assert coordinator.command_timeouts_in_window == 1
+
+
+# ------------------------------------------------------------ cloud transport
+
+
+def test_cloud_metrics_are_none_without_a_transport() -> None:
+    """None is not zero: no cloud transport is a different fact from no sends."""
+    coordinator = _bare_coordinator()
+    assert coordinator.cloud_sends_in_window is None
+    assert coordinator.cloud_send_limit_state is None
+
+
+@pytest.mark.parametrize(
+    ("rate_limited", "expected"), [(False, "ok"), (True, "rate_limited")]
+)
+def test_cloud_metrics_read_the_transport(rate_limited: bool, expected: str) -> None:
+    """Both budget sensors read straight off the live transport."""
+    coordinator = _bare_coordinator()
+    transport = SimpleNamespace(
+        sends_in_window=lambda: 42, is_rate_limited=rate_limited
+    )
+    coordinator.manager = SimpleNamespace(
+        mower=lambda _n: SimpleNamespace(
+            has_transport=lambda _t: True,
+            get_transport=lambda _t: transport,
+            is_transport_connected=lambda _t: True,
+        )
+    )
+    assert coordinator.cloud_sends_in_window == 42
+    assert coordinator.cloud_send_limit_state == expected
+
+
+def test_a_connected_transport_wins_over_a_registered_one() -> None:
+    """Two cloud transports can be registered; report the live one."""
+    coordinator = _bare_coordinator()
+    idle = SimpleNamespace(sends_in_window=lambda: 1, is_rate_limited=False)
+    live = SimpleNamespace(sends_in_window=lambda: 99, is_rate_limited=True)
+    transports = {
+        coordinator_module.TransportType.CLOUD_ALIYUN: idle,
+        coordinator_module.TransportType.CLOUD_MAMMOTION: live,
+    }
+    coordinator.manager = SimpleNamespace(
+        mower=lambda _n: SimpleNamespace(
+            has_transport=lambda t: t in transports,
+            get_transport=lambda t: transports[t],
+            is_transport_connected=lambda t: transports[t] is live,
+        )
+    )
+    assert coordinator.cloud_sends_in_window == 99
+    assert coordinator.cloud_send_limit_state == "rate_limited"
+
+
+def test_a_broken_transport_degrades_to_none_rather_than_raising() -> None:
+    """A diagnostic must never take the coordinator down with it."""
+    coordinator = _bare_coordinator()
+    broken = SimpleNamespace()  # neither attribute present
+    coordinator.manager = SimpleNamespace(
+        mower=lambda _n: SimpleNamespace(
+            has_transport=lambda _t: True,
+            get_transport=lambda _t: broken,
+            is_transport_connected=lambda _t: True,
+        )
+    )
+    assert coordinator.cloud_sends_in_window is None
+    assert coordinator.cloud_send_limit_state is None


### PR DESCRIPTION
Adapted from upstream PRs #800 (rotgier) and #836 (lightheaded) — reviewed against this tree rather than cherry-picked.

## What it adds

| entity | what it reports |
| --- | --- |
| `sensor.<device>_cloud_sends_24h` | rolling 24 h count of **physical** cloud sends, retries included |
| `sensor.<device>_cloud_send_limit` | `ok` / `rate_limited` |
| `sensor.<device>_command_timeouts_24h` | rolling 24 h `CommandTimeoutError` count |
| `button.<device>_refresh_status` | one-shot fresh device state |

## Why

The 2026-08-11 hardware session had to infer link degradation from `ble_rssi` plus a single failed run, and a distance-based explanation for it was floated and then withdrawn for lack of evidence. A counter beats an inference.

The button is the operator-facing equivalent of the `warm_ble_link` step the motion harness already runs: this mower dozes to `ble_rssi: 0` within ~10–13 min idle, after which every entity reads its last value and looks healthy.

## Dependencies — nothing new

Both upstream PRs assume APIs this tree already has:

- `async_ensure_fresh_state` already exists on our coordinator
- `sends_in_window` / `is_rate_limited` already exist on `Transport` in the pinned pymammotion

**No pymammotion pin was moved.** Ours is the Chorty fork wheel `chorty-0.8.12.post1`; the related upstream #834 pins 0.8.11, which would have been a downgrade.

## Two deliberate choices

**The timeout counter re-raises.** It sits in `async_send_command`, the single funnel every queued command passes through. Several callers already catch `CommandTimeoutError` and `pass`, so swallowing it there to tidy the accounting would silently change command behaviour. It counts and re-raises unchanged, and there is a test named for that property.

**Scope is documented, not implied.** The counter sees commands routed through `async_send_command` — **not** the motion executors in `services.py` — so it measures integration command health, not a motion run's. The cloud sensors return `None` rather than `0` when no cloud transport is registered, because "no transport" and "no sends" are different facts.

## Translations

All 12 locales plus `strings.json`: four names and both ENUM states, translated into each language rather than English-placeheld, with `icons.json` entries. Tests assert presence in every locale **and** that no non-English locale is a verbatim English copy. (Upstream #800 shipped `en` + `pl` only.)

The sweep produced insertions only, no deletions — the check that the reserialisation preserved every file's existing formatting.

## Verification

`597 pytest (14 new) · 20 frontend · ruff · ruff format · mypy · pre-commit` — all green.

## Base branch

Targets `feat/beta31-reach-and-overshoot-ceiling` rather than `main`, so the diff is this one commit instead of the 254 that branch carries.
