### PR TITLE
Fix Night Go control and Real Go feedback latency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,18 +10,43 @@ provenance — accurate as a record, but **do not act on any build state it
 describes**, and note that measurement has since refuted several of its claims
 (the "unexplained" turn-rate variance and the turn-budget framing, both below).
 
-## Current build: `0.6.4-beta52` — BETA, items 15–18 measured, gate disarmed
+## Current build: `0.6.4-beta54` released; night follow-up verified locally
 
-**Host and branch agree at `0.6.4-beta52`.**
-Card md5 `9512f504` at both serving paths, resource
-`?v=0.6.4-beta52&build=9512f504`. Gate **DISARMED**
-(`enabled: false`, `real_motion_allowed: false`, no active session). The
-motion-disabled deploy sent no movement command. Beta52 adds runtime-only
-RapidState fusion diagnostics and a fixed backward-only item-17 harness; its
-final integration gates produced **662 pytest, 39 frontend**, with ruff, format, mypy
-and all pre-commit hooks green. `LUBA_ACCEPTANCE_PROFILE` values are unchanged.
-After the item-18 harness-only safety pins, the full suite produced **664 pytest,
-39 frontend**, with the other four commands green.
+`main`, `origin/main`, and tag `v0.6.4-beta54` agree at `0bd35160`. Beta54 adds
+the guarded **Night dry-run** and **Night Go** card controls without changing
+any value in `LUBA_ACCEPTANCE_PROFILE`; Real Go remains the accepted VIO path.
+The beta54 motion-disabled installation and subsequent supervised card run are
+complete. The motion gate was verified **DISARMED** afterward
+(`real_motion_allowed: false`, no active session).
+
+One beta54 card-driven 0.739138 m Night Go stopped safely on
+`no_target_progress` at 0.117085 m after three turn and three forward commands.
+The second forward pulse had settled only 0.002661 m outside the configured
+0.08 m tolerance, but the controller reused a pre-pulse target bearing and sent
+an unnecessary third pulse after crossing the target. Read
+`docs/night-go-card-beta54-20260814.md`.
+
+The working tree contains an **uncommitted** night-only fix: use
+the settled post-pulse RTK position for the residual target bearing, allowing
+the existing reverse-recovery refusal to stop after an overshoot. The card and
+harness also send `sample_delays: [0, 3]`; beta54 omitted it and inherited the
+backend's `[0, 5, 10, 20, 30, 45, 60]`, making the physical run take about 6.5
+minutes. It also contains a Real Go throughput fix: VIO calibration now waits
+one four-second feedback window instead of 2+4 seconds, settled linear telemetry
+is reused instead of adding another three-second sample wait, and the card does
+one final runtime reload instead of two. The dispatched Real Go payload, stops,
+safety gates, legacy/night timing, frozen acceptance-profile values, and all
+`vio_active` construction sites remain unchanged. The VIO response now records
+`post_settle_feedback` and one settled-position sample per successful pulse.
+Final local verification produced **668 pytest and 46 frontend tests**; ruff
+check, ruff format check, mypy, and all pre-commit hooks passed. Both fixes are
+unreleased. They are deployed motion-disabled for testing. The first supervised
+Real Go throughput run safely refused its second linear command because the
+position-feedback report requests still occupied the BLE queue. A bounded
+post-feedback queue-settle correction was then deployed. A fresh supervised
+0.70 m Real Go run reached its target in 19.2 s with 0.093100 m landing error;
+all three queue-settle records were live at depth zero and every movement/stop
+succeeded. Read `docs/real-go-throughput-hardware-20260814.md`.
 
 ✅ **§7 item 17 is complete.** One backward-only pulse moved 0.418536 m on map
 bearing 96.433921° while `toward` remained bit-identical at 173.1023°. The
@@ -71,8 +96,13 @@ defects that only appeared when the card was rendered against **real**
 backend lists, two emitted codes with no help text, a restored run presented as
 current, and a tofu-risk glyph. **Render against live state, not fixtures.**
 
-🚨 **A night SEGMENT will not work today, and the reason is two missing
-parameters — not the turn primitive.** The segment executor's legacy branch
+> **Historical pre-night-v1 finding (superseded by beta50+):** A night segment
+> did not work through the legacy branch because of two missing parameters,
+> not because of the turn primitive. The dedicated `turn_mode: "night"` branch
+> now supplies both and beta54 exposes it through Night Go. The legacy branch
+> remains deliberately unchanged.
+
+The segment executor's legacy branch
 (`services.py:11498-11517`) omits `motion_refresh_interval_ms` (primitive default
 `0`) and passes `angular_speed_fast/slow` at the schema default **180**, which
 does not break static friction on a stationary pivot (~3°/pulse). Every
@@ -105,9 +135,10 @@ the VIO path's `_turn_final_approach_pulse_ms` **window scaling** into the legac
 turn — scale the window, ⚠️ **not** the speed (`angular_speed_slow: 180` sits in
 the stationary deadband; the slow tier has never actually engaged).
 ⚠️ A turn is not a segment; `vio_active` still refuses `turn_mode: "vio"`; and
-🚨 **the map→`toward` conversion is wrong by construction** (mirror, not the
-additive 102.4) — every target above was passed by hand to bypass it, and a night
-segment would hit it.
+🚨 **the shared legacy map→`toward` conversion is wrong by construction**
+(mirror, not the additive 102.4). Night v1 contains this by applying the mirror
+strictly inside `turn_mode: "night"`; the two cancelling legacy conversion sites
+remain deliberately unchanged.
 
 
 `docs/NEXT-SESSION.md` carries the live mower state; this section carries what

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ provenance — accurate as a record, but **do not act on any build state it
 describes**, and note that measurement has since refuted several of its claims
 (the "unexplained" turn-rate variance and the turn-budget framing, both below).
 
-## Current build: `0.6.4-beta54` released; night follow-up verified locally
+## Current build: `0.6.4-beta54` released; follow-up is draft PR #14
 
 `main`, `origin/main`, and tag `v0.6.4-beta54` agree at `0bd35160`. Beta54 adds
 the guarded **Night dry-run** and **Night Go** card controls without changing
@@ -26,7 +26,9 @@ The second forward pulse had settled only 0.002661 m outside the configured
 an unnecessary third pulse after crossing the target. Read
 `docs/night-go-card-beta54-20260814.md`.
 
-The working tree contains an **uncommitted** night-only fix: use
+Branch `agent/night-real-go-followup` is pushed to the Chorty fork at
+`801c1798`; draft PR #14 targets `main`. Raw evidence is isolated in preceding
+commit `dd53e266`. The branch contains a night-only fix: use
 the settled post-pulse RTK position for the residual target bearing, allowing
 the existing reverse-recovery refusal to stop after an overshoot. The card and
 harness also send `sample_delays: [0, 3]`; beta54 omitted it and inherited the
@@ -40,7 +42,8 @@ safety gates, legacy/night timing, frozen acceptance-profile values, and all
 `post_settle_feedback` and one settled-position sample per successful pulse.
 Final local verification produced **668 pytest and 46 frontend tests**; ruff
 check, ruff format check, mypy, and all pre-commit hooks passed. Both fixes are
-unreleased. They are deployed motion-disabled for testing. The first supervised
+unreleased. They are deployed motion-disabled for testing. PR #14's Python,
+hassfest, and Socket checks passed; HACS was skipped by workflow policy. The first supervised
 Real Go throughput run safely refused its second linear command because the
 position-feedback report requests still occupied the BLE queue. A bounded
 post-feedback queue-settle correction was then deployed. A fresh supervised

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,10 @@ The second forward pulse had settled only 0.002661 m outside the configured
 an unnecessary third pulse after crossing the target. Read
 `docs/night-go-card-beta54-20260814.md`.
 
-Branch `agent/night-real-go-followup` is pushed to the Chorty fork at
-`801c1798`; draft PR #14 targets `main`. Raw evidence is isolated in preceding
-commit `dd53e266`. The branch contains a night-only fix: use
+Branch `agent/night-real-go-followup` is pushed to the Chorty fork; draft PR
+#14 targets `main`. Raw evidence is isolated in commit `dd53e266`, and the code
+and tests are in `801c1798`; later commits reconcile handoff documentation. The
+branch contains a night-only fix: use
 the settled post-pulse RTK position for the residual target bearing, allowing
 the existing reverse-recovery refusal to stop after an overshoot. The card and
 harness also send `sample_delays: [0, 3]`; beta54 omitted it and inherited the
@@ -43,8 +44,8 @@ safety gates, legacy/night timing, frozen acceptance-profile values, and all
 Final local verification produced **668 pytest and 46 frontend tests**; ruff
 check, ruff format check, mypy, and all pre-commit hooks passed. Both fixes are
 unreleased. They are deployed motion-disabled for testing. PR #14's Python,
-hassfest, and Socket checks passed; HACS was skipped by workflow policy. The first supervised
-Real Go throughput run safely refused its second linear command because the
+hassfest, and Socket checks passed; HACS was skipped by workflow policy. The
+first supervised Real Go throughput run safely refused its second linear command because the
 position-feedback report requests still occupied the BLE queue. A bounded
 post-feedback queue-settle correction was then deployed. A fresh supervised
 0.70 m Real Go run reached its target in 19.2 s with 0.093100 m landing error;

--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ Notes on the profile:
   assuming 102.4 transfers.
 - `ble_auto_recover: false` keeps a failed BLE gate a fast failure rather than
   a ~90 s in-run recovery attempt.
+- The current unreleased Real Go throughput fix preserves this exact payload and
+  every mandatory stop. It removes additive feedback waits by using the VIO
+  position-settle result as the post-pulse sample, reduces cold VIO calibration
+  from a 2+4-second wait to one four-second window, and removes a duplicate
+  final card reload. It is verified off-mower but not yet deployed or measured
+  on hardware.
 - `heading_tolerance_degrees: 18` is a known-loose value carried over from the
   July 18 calibration. It is unchanged from the accepted run, but reducing it
   is open beta work.
@@ -259,11 +265,21 @@ accuracy and a supported tolerance remain unproven. Use **Night dry-run** first,
 watch the mower continuously, and retain the complete result JSON from every
 physical run.
 
-One supervised 0.70 m night segment reached its opening 8° turn tolerance and
+One supervised 0.70 m harness segment reached its opening 8° turn tolerance and
 stopped safely on `no_target_progress` 0.1143 m from target after three forward
-pulses. That records feasibility; it does not establish a night accuracy
-tolerance or acceptance population. Use the accepted VIO card profile for
-ordinary click-to-go operation.
+pulses. A later beta54 card-driven 0.739 m run also stopped safely after three
+turn and three forward commands, 0.1171 m from target. In that run the second
+forward pulse was already 0.0827 m away, but a stale pre-pulse target bearing
+allowed a third pulse after the mower crossed the target. See
+`docs/night-go-card-beta54-20260814.md`.
+
+The current local follow-up recomputes that night-only residual bearing from
+the settled post-pulse RTK position and sends `sample_delays: [0, 3]` from Night
+Go to avoid beta54's inherited minute-long diagnostic waits. It is verified
+off-mower but is not yet released, deployed, or hardware-tested. These runs
+record feasibility; they do not establish a night accuracy tolerance or
+acceptance population. Use the accepted VIO card profile for ordinary
+click-to-go operation.
 
 Real motion additionally requires the integration option **Enable experimental
 BLE-only manual motion**, a positively verified PyMammotion backend, a fresh

--- a/README.md
+++ b/README.md
@@ -206,12 +206,16 @@ Notes on the profile:
   assuming 102.4 transfers.
 - `ble_auto_recover: false` keeps a failed BLE gate a fast failure rather than
   a ~90 s in-run recovery attempt.
-- The current unreleased Real Go throughput fix preserves this exact payload and
-  every mandatory stop. It removes additive feedback waits by using the VIO
-  position-settle result as the post-pulse sample, reduces cold VIO calibration
-  from a 2+4-second wait to one four-second window, and removes a duplicate
-  final card reload. It is verified off-mower but not yet deployed or measured
-  on hardware.
+- The Real Go throughput fix preserves this exact payload and every mandatory
+  stop. It removes additive feedback waits by using the VIO position-settle
+  result as the post-pulse sample, reduces cold VIO calibration from a
+  2+4-second wait to one four-second window, and removes a duplicate final card
+  reload. After it, each pulse also runs a bounded BLE queue-settle check and
+  refuses the next command with `ble_link_not_ready_after_feedback` rather than
+  dispatching into a backlog. One supervised 0.70 m run reached its target in
+  19.2 s with 0.093100 m landing error, all three queue-settle records live at
+  depth zero. That is a single path, not a reliability population. See
+  `docs/real-go-throughput-hardware-20260814.md`.
 - `heading_tolerance_degrees: 18` is a known-loose value carried over from the
   July 18 calibration. It is unchanged from the accepted run, but reducing it
   is open beta work.
@@ -273,13 +277,17 @@ forward pulse was already 0.0827 m away, but a stale pre-pulse target bearing
 allowed a third pulse after the mower crossed the target. See
 `docs/night-go-card-beta54-20260814.md`.
 
-The current local follow-up recomputes that night-only residual bearing from
-the settled post-pulse RTK position and sends `sample_delays: [0, 3]` from Night
-Go to avoid beta54's inherited minute-long diagnostic waits. It is verified
-off-mower but is not yet released, deployed, or hardware-tested. These runs
-record feasibility; they do not establish a night accuracy tolerance or
-acceptance population. Use the accepted VIO card profile for ordinary
-click-to-go operation.
+The follow-up recomputes that night-only residual bearing from the settled
+post-pulse RTK position, so the existing reverse-recovery refusal stops a
+crossed waypoint, and sends `sample_delays: [0, 3]` from Night Go to avoid
+beta54's inherited minute-long diagnostic waits. Replayed against the recorded
+beta54 geometry it refuses the third pulse and lands 0.0827 m out instead of
+0.1171 m — still outside the configured 0.08 m tolerance, so it stops on
+`target_requires_reverse_recovery` rather than reaching target. It is verified
+off-mower and installed motion-disabled, but **no night run has exercised it on
+hardware**. These runs record feasibility; they do not establish a night
+accuracy tolerance or acceptance population. Use the accepted VIO card profile
+for ordinary click-to-go operation.
 
 Real motion additionally requires the integration option **Enable experimental
 BLE-only manual motion**, a positively verified PyMammotion backend, a fresh

--- a/custom_components/mammotion/services.py
+++ b/custom_components/mammotion/services.py
@@ -8980,10 +8980,9 @@ async def _settle_linear_position_feed(
     # all returned the exact same coordinates. One poll proves nothing.
     feed_stale = polls >= _STALE_FEED_MIN_POLLS and not observed_jitter
     return {
-        # The settled snapshot. Currently informational: callers re-sample via
-        # their sample_delays for `after`. Reserved as the hook for the deferred
-        # throughput fix (use this directly as `after` and trim sample_delays so
-        # the settle wait and the sampling wait stop being additive).
+        # The settled snapshot is also the VIO path's authoritative post-pulse
+        # sample. Reusing it avoids waiting through `sample_delays` after this
+        # loop has already established both movement and stillness.
         "telemetry": previous,
         "settled": settled,
         "moved": moved,
@@ -11041,8 +11040,13 @@ async def _vio_segment_calibration_drive(  # noqa: C901, PLR0913
             result["command_results"].append(command_result)
             result["reason"] = "stop_failed_aborting"
             return result
+        # Request reports immediately, then give the asynchronous position feed
+        # one total settling window. The refresh helper normally includes its
+        # own two-second sleep; adding the four-second VIO calibration wait made
+        # every cold-start pulse idle for six seconds. Real Go needs the measured
+        # four-second feed-latency window once.
         command_result["feedback_refresh"] = await _refresh_position_after_raw_motion(
-            coordinator
+            coordinator, settle_seconds=0.0
         )
         await asyncio.sleep(max(refresh_wait_seconds, 0.5))
         result["command_results"].append(command_result)
@@ -12171,7 +12175,14 @@ async def _raw_pymammotion_execute_vector_segment(  # noqa: C901, PLR0913
             return result
         command_result[
             "post_command_feedback_refresh"
-        ] = await _refresh_position_after_raw_motion(coordinator)
+        ] = await _refresh_position_after_raw_motion(
+            coordinator,
+            # The VIO path immediately enters the bounded position-settle loop,
+            # which requests the same reports once per second. Do not sleep two
+            # seconds here and then start that loop; night and legacy retain
+            # their established timing byte-for-byte.
+            settle_seconds=0.0 if turn_mode == "vio" else 2.0,
+        )
         # The map-local feed lags ~4s and jumps: wait for this pulse's motion to
         # register and settle before sampling, so the samples below (and thus the
         # progress/completion checks) reflect THIS pulse instead of leaking a prior
@@ -12186,6 +12197,24 @@ async def _raw_pymammotion_execute_vector_segment(  # noqa: C901, PLR0913
         command_result["position_settle_polls"] = position_settle["settle_polls"]
         if position_settle["moved"]:
             feed_moved_earlier = True
+        post_feedback_queue_settle: dict[str, Any] | None = None
+        if turn_mode == "vio":
+            # The position-settle loop requests five reports on every poll.
+            # Those requests share the BLE command queue with motion. The first
+            # hardware run without the old blind three-second wait settled its
+            # position in 2.03 s but refused the next pulse on
+            # `command_queue_backlogged`. Wait for the queue itself instead:
+            # this returns immediately when empty, remains bounded at six
+            # seconds, and never converts a persistent backlog into a pass.
+            queue_started = time.monotonic()
+            post_feedback_queue_settle = await _settle_ble_command_queue(coordinator)
+            command_result["post_feedback_queue_settle"] = {
+                **post_feedback_queue_settle,
+                "duration_ms": round(
+                    (time.monotonic() - queue_started) * 1000,
+                    3,
+                ),
+            }
         # Phantom-motion investigation instrumentation (capture only): log both
         # position sources + RTK quality so a later run can tell a real move from a
         # feed-jump on a no-op pulse.
@@ -12194,19 +12223,55 @@ async def _raw_pymammotion_execute_vector_segment(  # noqa: C901, PLR0913
         )
 
         command_samples: list[dict[str, Any]] = []
-        previous_delay = 0.0
-        for sample_index, delay in enumerate(sample_delays):
-            await asyncio.sleep(max(0.0, float(delay) - previous_delay))
-            previous_delay = float(delay)
-            sample_telemetry = _custom_path_telemetry_snapshot(coordinator)
+        settled_telemetry = position_settle.get("telemetry")
+        reuse_settled_telemetry = (
+            turn_mode == "vio"
+            and position_settle["settled"] is True
+            and isinstance(settled_telemetry, dict)
+        )
+        if reuse_settled_telemetry:
+            # Real Go has already paid the bounded 1-6 second position-settle
+            # wait. Waiting through [0, 3] afterward sampled the same stopped
+            # mower and made the two feedback windows additive. Keep one
+            # per-command record, but make its source and actual wait explicit.
             sample = {
-                "label": f"linear_{command_index}_sample_{sample_index + 1}_{delay:g}s",
+                "label": f"linear_{command_index}_position_settled",
                 "command_index": command_index,
-                "delay_seconds": float(delay),
-                "telemetry": sample_telemetry,
+                "delay_seconds": position_settle["wait_seconds"],
+                "source": "position_settle",
+                "telemetry": settled_telemetry,
             }
             result["samples"].append(sample)
             command_samples.append(sample)
+            command_result["post_settle_feedback"] = {
+                "source": "position_settle",
+                "additional_wait_seconds": 0.0,
+                "requested_sample_delays_skipped": list(sample_delays),
+            }
+        else:
+            previous_delay = 0.0
+            for sample_index, delay in enumerate(sample_delays):
+                await asyncio.sleep(max(0.0, float(delay) - previous_delay))
+                previous_delay = float(delay)
+                sample_telemetry = _custom_path_telemetry_snapshot(coordinator)
+                sample = {
+                    "label": (
+                        f"linear_{command_index}_sample_{sample_index + 1}_{delay:g}s"
+                    ),
+                    "command_index": command_index,
+                    "delay_seconds": float(delay),
+                    "telemetry": sample_telemetry,
+                }
+                result["samples"].append(sample)
+                command_samples.append(sample)
+            if turn_mode == "vio":
+                command_result["post_settle_feedback"] = {
+                    "source": "post_settle_samples",
+                    "additional_wait_seconds": max(
+                        (float(delay) for delay in sample_delays), default=0.0
+                    ),
+                    "requested_sample_delays_skipped": [],
+                }
 
         after = (
             command_samples[-1]["telemetry"]
@@ -12271,6 +12336,13 @@ async def _raw_pymammotion_execute_vector_segment(  # noqa: C901, PLR0913
                     },
                 }
             )
+            return result
+        if (
+            post_feedback_queue_settle is not None
+            and not post_feedback_queue_settle.get("live")
+        ):
+            result["stop_reason"] = "ble_link_not_ready_after_feedback"
+            result["post_feedback_queue_settle"] = post_feedback_queue_settle
             return result
         quality = _manual_velocity_quality_degradation(baseline_telemetry, after)
         if quality["degraded"]:
@@ -12483,8 +12555,20 @@ async def _raw_pymammotion_execute_vector_segment(  # noqa: C901, PLR0913
         elif turn_mode == "night":
             # Both values are map-frame bearings derived from RTK position; VIO
             # and ``toward`` are not used to decide this per-pulse aim check.
+            # The bearing must start at the SETTLED POST-PULSE position. Using
+            # the shared progress diagnostic's pre-pulse bearing misses a target
+            # that the pulse has just passed: measured 2026-08-14, pulse 2
+            # settled 0.08266 m from an 0.08 m target with the residual bearing
+            # at 155.64 deg, but its pre-pulse 9.26 deg bearing allowed a third
+            # forward write that worsened the landing to 0.11708 m. Keep the
+            # shared diagnostic unchanged; this correction is night-only.
             movement_heading = progress.get("movement_vector_heading_degrees")
-            night_bearing = progress.get("expected_target_heading_degrees")
+            night_residual_point = _raw_segment_current_point(after)
+            night_bearing = (
+                _path_heading_degrees(night_residual_point, target)
+                if night_residual_point is not None
+                else None
+            )
             measured_distance = (progress.get("measured_delta") or {}).get("distance")
             night_distance_to_target = completion_status.get("distance_to_target")
             after_toward = (after.get("position") or {}).get("toward")

--- a/custom_components/mammotion/www/mammotion-custom-path-card.js
+++ b/custom_components/mammotion/www/mammotion-custom-path-card.js
@@ -25,6 +25,12 @@ const NIGHT_GO_PROFILE = Object.freeze({
   ble_auto_recover: false,
   night_angular_speed: 500,
   toward_mirror_degrees: 90.13,
+  // The backend's diagnostic default samples through 60 seconds after EVERY
+  // command. On the first card-driven night run (2026-08-14), all three turn
+  // heading changes were visible within 3 seconds, while the inherited default
+  // stretched 3 turn + 3 linear commands to about 6.5 minutes. Night owns this
+  // value so the frozen daylight profile and its dispatched payload do not move.
+  sample_delays: [0, 3],
 });
 // Bump on EVERY deploy (date + b-counter) so the footer/console banner proves
 // which build the browser actually loaded.
@@ -1375,6 +1381,7 @@ class MammotionCustomPathCard extends HTMLElement {
       ble_auto_recover: NIGHT_GO_PROFILE.ble_auto_recover,
       night_angular_speed: NIGHT_GO_PROFILE.night_angular_speed,
       toward_mirror_degrees: NIGHT_GO_PROFILE.toward_mirror_degrees,
+      sample_delays: NIGHT_GO_PROFILE.sample_delays,
     };
     // Deliberately OMIT max_linear_pulse_ceiling. Night v1 is fixed-budget;
     // sending the accepted daylight ceiling would be refused by the backend.
@@ -1636,8 +1643,6 @@ class MammotionCustomPathCard extends HTMLElement {
         })),
         summary: this._segmentProgressText(this._realRun),
       });
-      await this._loadRuntimeState();
-      this._render();
     } catch (err) {
       this._stopRunTicker();
       this._status = `Real Go failed: ${err?.message || err}`;

--- a/docs/CLAUDE-FINAL-IMPLEMENTATION-PROMPT.md
+++ b/docs/CLAUDE-FINAL-IMPLEMENTATION-PROMPT.md
@@ -1,75 +1,140 @@
-# Claude handoff — finish the blocked beta19 VIO-turn implementation
+# Claude handoff — independently review and release PR #14
 
-You are continuing `Chorty/Mammotion-HA` on branch
-`feat/vio-turn-to-heading`. Read `CLAUDE.md`, then
-`docs/CODEX-HANDOFF.md`, before editing.
+You are taking over `Chorty/Mammotion-HA` after the beta54 Night Go and Real Go
+throughput follow-up. Work from the repo root on the current tip of
+`agent/night-real-go-followup`. Draft PR #14 targets `main` at released/tagged
+`0.6.4-beta54` (`0bd35160`). The branch is pushed and clean. Raw hardware
+evidence is commit `dd53e266`; implementation/tests are commit `801c1798`;
+later commits only reconcile the handoff documents. Confirm the current PR head
+instead of assuming a SHA from this prompt.
 
-## Non-negotiable safety state
+## Read first, in order
 
-Experimental motion is **off**, no session is active, and the mower was last
-stationary at approximately `(5.4960, -2.8510)`. Do not arm, deploy, command,
-or click Real Go. Any later live diagnostic requires explicit fresh operator
-confirmation, daylight, blades physically off, clear path, released e-stop,
-and direct observation.
+1. `CLAUDE.md`, starting at **Current build**.
+2. The 2026-08-14 handoff at the top of `docs/NEXT-SESSION.md`. Treat everything
+   below that live section as measurement history, not current build state.
+3. `docs/CODEX-HANDOFF.md`.
+4. `docs/real-go-throughput-hardware-20260814.md` and both raw JSON records it
+   links.
+5. `docs/night-go-card-beta54-20260814.md` and its raw JSON record.
+6. Section 4 of `docs/night-segment-implementation-plan-v1-20260813.md` before
+   proposing any motion-path change.
 
-## Exact blocking fact
+## Your job
 
-The 2026-08-03 Gate 4 retry used the guarded multi-segment VIO executor. The
-durable result is
-`docs/evidence-gate4-beta19-retry-real-result-20260803.json`; its offline
-summary is `docs/evidence-gate4-beta19-retry-diagnosis-20260803.json`.
+Act as the independent reviewer for draft PR #14. Do not rubber-stamp it merely
+because local tests and CI are green.
 
-Segment 1 stopped `turn_phase_incomplete` because its VIO turn returned
-`max_commands_reached`:
+1. Review the complete diff from beta54 to the PR tip, including every
+   per-command hardware record.
+2. Confirm the invariants below and resolve any review finding before merging.
+3. Run the exact six-command suite below if you change anything. If you make no
+   change, independently inspect the existing local/CI records and state what
+   you personally reran.
+4. When satisfied, mark PR #14 ready and merge it into the Chorty fork only.
+   Never push, comment, or merge on a `mikey0000` repository.
+5. Prepare the next beta using the repository's established beta workflow
+   (expected next identifier: `0.6.4-beta55`; verify rather than assume).
+6. Install that beta on Home Assistant **motion-disabled**, following
+   `docs/deploy-runbook-p0.md`: back up first, deploy the complete integration,
+   synchronize both card-serving paths, update the Lovelace resource with the
+   card checksum suffix, restart, and verify exact hashes, version quartet,
+   pymammotion version, entity recovery, and gate state.
+7. Finish with `experimental motion: off`, `real_motion_allowed: false`, and no
+   active session. Report the measured deployment results and actual test counts.
 
-- calibration passed: map/VIO offset `3.779947°`, 0.101625 m calibration move;
-- target map heading `177.671979°`; target VIO heading `173.892032°`;
-- four `-500` turn commands made positive progress (24.805°, 36.423°, 34.741°,
-  36.648°), ending at `139.097502°`;
-- final error was `34.795°`, above the 18° tolerance;
-- total turn translation was `0.185095 m`, below its 0.25 m displacement cap;
-- `linear_commands_sent: 0`, so this was not
-  `max_linear_commands_reached`; segment 2 did not start.
+## What PR #14 changes
 
-The retained profile is an accepted profile; do not tune its 102.4° heading
-offset or simply raise an execution budget on this single geometry.
+- Night Go recomputes the residual target bearing from settled post-pulse RTK
+  position. This lets the existing reverse-recovery refusal stop a crossed
+  waypoint instead of sending another forward pulse.
+- The separate Night Go profile and harness send `sample_delays: [0, 3]`. Beta54
+  inherited a diagnostic schedule through 60 seconds and made six bounded
+  commands take about 6.5 minutes.
+- Real Go removes additive feedback waits: VIO calibration uses one four-second
+  window, settled linear telemetry is reused, and the card removes one duplicate
+  successful runtime reload.
+- After each VIO settled-position check, the executor runs the existing bounded
+  BLE queue-settle helper. It records `post_feedback_queue_settle` and refuses
+  with `ble_link_not_ready_after_feedback` if the queue remains non-live.
 
-## Implementation objective
+The first optimized hardware run is an important safe-failure record: after one
+successful forward pulse, the standing gate refused the second before dispatch
+with `command_queue_backlogged`. That was not a BLE disconnect. The bounded
+queue-settle correction was then deployed, and a separately authorized 0.70 m
+Real Go run reached `target_reached` in 19.2 seconds with 0.093100 m landing
+error. Its three queue-settle records reached depth zero in about 100–101 ms;
+all movement commands and mandatory stops succeeded. The gate was independently
+verified off afterward.
 
-Implement a conservative, test-covered turn-planning correction that prevents
-an obviously unfinishable near-180° VIO turn from entering a multi-segment
-path. Prefer a fail-closed preflight/plan outcome or a bounded, explicitly
-tested strategy over silently expanding physical-motion authority.
+## Review invariants
 
-The implementation must:
+- `LUBA_ACCEPTANCE_PROFILE` must remain byte-identical to beta54. The prior
+  review computed the same SHA-256 on both sides:
+  `e58c270c188ff5e25339d30b341d6f8151164115b4b77e50754852a66a5923c1`.
+- The legacy turn branch must remain byte-identical, including angular 180 and
+  the omitted refresh kwarg. Prior review hash:
+  `c9165d36fc9837a0c227d788d1770712322ecad16eaaf324067a8365b06b255f`.
+- All nine original `turn_mode == "vio"` safety/control blocks and both
+  `vio_active` construction sites remain intact. PR #14 adds VIO-scoped feedback
+  handling; it does not bypass those gates.
+- Real Go's dispatched card payload remains sourced from the frozen profile.
+- The VIO response is intentionally **not** byte-identical to beta54: it adds
+  settled-feedback and queue-settle provenance. Do not remove those fields to
+  satisfy the older night-v1 response-invariance wording. The heading conversion
+  and accepted-profile echo remain unchanged.
+- Night and legacy feedback timing are unchanged by the Real Go optimization.
+- No entity, enum, translation, icon, or import change is required by this PR.
 
-1. preserve the existing service schema and fail-closed behavior for non-LUBA
-   hardware;
-2. expose enough result diagnostics to distinguish turn budget exhaustion from
-   linear budget exhaustion without relying on ephemeral command output;
-3. use the observed turn progress/translation evidence when assessing whether a
-   target is feasible under the configured `vio_turn_max_commands`, tolerance,
-   pulse cadence, and displacement cap;
-4. refuse execution with a specific stop reason if the requested turn cannot be
-   bounded safely, rather than automatically increasing the turn budget;
-5. add focused Python tests for the observed near-180° scenario, an already
-   feasible turn, and result diagnostics; and
-6. leave `LUBA_ACCEPTANCE_PROFILE` and all four beta19 version locations
-   unchanged unless a separate, reviewed release decision says otherwise.
+## Exact verification commands
 
-`scripts/run_motion_with_evidence.py` now records the service response and
-telemetry in the same foreground process. `scripts/diagnose_motion_result.py`
-is offline and classifies failed turn versus failed linear phase. Keep them
-usable and add tests if their behavior changes.
+There is no global `uv`; use the project venv.
 
-## Verification and handoff
+```sh
+.venv/bin/python -m pytest --cov=custom_components.mammotion --cov-report=term-missing tests
+.venv/bin/python -m ruff check custom_components tests
+.venv/bin/python -m ruff format --check custom_components tests
+.venv/bin/python -m mypy --follow-imports=skip custom_components/mammotion
+npm run test:frontend
+.venv/bin/python -m pre_commit run --all-files
+```
 
-Run the CI-equivalent suite from `CLAUDE.md`, plus focused tests for the new
-turn-planning behavior. Update `docs/CODEX-HANDOFF.md`, `docs/NEXT-SESSION.md`,
-and `docs/deploy-runbook-p0.md` with the implemented behavior and its test
-evidence. Commit and push only to `Chorty/feat/vio-turn-to-heading`; never act
-on a `mikey0000` repository.
+The implementation session personally produced 668 pytest passes at 50%
+coverage and 46 frontend passes. Ruff check, Ruff format (58 files), mypy (28
+source files), and all nine pre-commit hooks passed. PR #14's Python, hassfest,
+and Socket checks passed; HACS was skipped by workflow policy. These are prior
+facts, not permission to quote them as newly run results.
 
-Do not mark PR #10 ready, merge, publish beta20, or attempt Gate 5. A future
-supervised daylight turn characterization must independently confirm the
-implementation before Gate 4 is retried.
+## Safety boundary
+
+This handoff authorizes repository review, Chorty PR/release work, and a
+motion-disabled Home Assistant installation. It authorizes **no mower motion**.
+
+- Do not enable experimental motion.
+- Do not arm the motion gate.
+- Do not send a movement command or run an armed harness mode.
+- Do not infer authorization from earlier supervised runs; each was consumed.
+- No additional motion test is required for this beta release.
+- If a later hardware movement is proposed, stop and obtain fresh, exact,
+  per-run supervised authorization.
+
+## Advice from the implementation session
+
+- Treat per-command records as authoritative. Aggregate stop reasons hid both
+  the safe pre-dispatch backlog refusal and earlier crossed-target behavior.
+- Do not replace the bounded queue check with another blind sleep. The queue
+  reached depth zero in ~100 ms on the successful run; a fixed delay would be
+  slower when healthy and less safe when unhealthy.
+- Do not interpret the one Real Go pass as a reliability population. It proves
+  the specific correction on one path.
+- Do not claim night landing accuracy. Night item 18 and the beta54 card run are
+  characterization, and the item-15 forward-course/mirror disagreement remains
+  unresolved.
+- The card is served from two paths. A correct backend deploy with a stale card
+  cache is still a failed deployment.
+- If review finds a safety or invariance defect, keep the PR draft and stop
+  before merge/release. Green CI is necessary, not sufficient.
+
+Report back with the review findings first, then PR/merge/release identifiers,
+actual verification counts, deployed hashes, restart/entity timings, and final
+motion-gate readback.

--- a/docs/CODEX-HANDOFF-PROMPT.md
+++ b/docs/CODEX-HANDOFF-PROMPT.md
@@ -2,8 +2,8 @@
 
 Paste everything between the rules below into Codex as the opening message.
 Updated 2026-08-14 after released/deployed `0.6.4-beta54`, its first supervised
-card-driven Night Go, and the verified/deployed but uncommitted Night and Real
-Go follow-ups.
+card-driven Night Go, and the verified/deployed Night and Real Go follow-ups in
+draft PR #14.
 
 ⚠️ Codex reads `AGENTS.md` by convention; this repo's instructions live in
 `CLAUDE.md`. The prompt below points at it explicitly, so no rename is needed —
@@ -21,8 +21,9 @@ LUBA robot mower to points clicked on a map, **with the blades OFF**. The goal i
 point-and-click movement, not mowing. It is at BETA; five acceptance gates are
 complete and Gate 5 has passed twice.
 
-Working directory is the repo root. Branch: `main`; `HEAD`, `origin/main`, and
-`v0.6.4-beta54` agreed at `0bd35160` before the current working-tree changes.
+Working directory is the repo root. Branch: `agent/night-real-go-followup` at
+`801c1798`, clean and pushed; draft PR #14 targets `main`. Raw evidence is in
+preceding commit `dd53e266`. `main`, `origin/main`, and `v0.6.4-beta54` agree at `0bd35160`.
 `origin` is the **Chorty** fork —
 `mikey0000/*` repositories are strictly read-only, never push or comment there.
 
@@ -61,7 +62,7 @@ the target. A pre-pulse bearing was reused after the mower crossed the target,
 causing the unnecessary third pulse. Read
 `docs/night-go-card-beta54-20260814.md`.
 
-The working tree has uncommitted, unreleased night and Real Go fixes. Night
+The PR branch has committed, unreleased night and Real Go fixes. Night
 calculates the residual bearing from settled post-pulse RTK and sends
 `sample_delays: [0, 3]` from the card/harness. Real Go now uses one four-second
 VIO-calibration feedback window, reuses settled linear telemetry instead of
@@ -138,8 +139,8 @@ npm run test:frontend
 .venv/bin/python -m pre_commit run --all-files
 ```
 
-Current follow-up-tree results personally produced: **668 pytest, 46 frontend**,
-all six commands green. **Run them again after any change and report the counts you
+Current PR #14 code results personally produced: **668 pytest, 46 frontend**,
+all six commands green; GitHub Python/hassfest/Socket checks passed. **Run them again after any change and report the counts you
 actually produced** — do not quote a number you did not
 generate. If something fails, paste the real traceback rather than summarising.
 

--- a/docs/CODEX-HANDOFF-PROMPT.md
+++ b/docs/CODEX-HANDOFF-PROMPT.md
@@ -21,9 +21,10 @@ LUBA robot mower to points clicked on a map, **with the blades OFF**. The goal i
 point-and-click movement, not mowing. It is at BETA; five acceptance gates are
 complete and Gate 5 has passed twice.
 
-Working directory is the repo root. Branch: `agent/night-real-go-followup` at
-`801c1798`, clean and pushed; draft PR #14 targets `main`. Raw evidence is in
-preceding commit `dd53e266`. `main`, `origin/main`, and `v0.6.4-beta54` agree at `0bd35160`.
+Working directory is the repo root. Branch: `agent/night-real-go-followup`,
+clean and pushed; draft PR #14 targets `main`. Raw evidence is in commit
+`dd53e266`, implementation/tests in `801c1798`, and later commits only reconcile
+handoff docs. `main`, `origin/main`, and `v0.6.4-beta54` agree at `0bd35160`.
 `origin` is the **Chorty** fork —
 `mikey0000/*` repositories are strictly read-only, never push or comment there.
 

--- a/docs/CODEX-HANDOFF-PROMPT.md
+++ b/docs/CODEX-HANDOFF-PROMPT.md
@@ -1,7 +1,9 @@
 # Codex handoff prompt
 
 Paste everything between the rules below into Codex as the opening message.
-Updated 2026-08-14 after deployed `0.6.4-beta52` night v1 items 15–18.
+Updated 2026-08-14 after released/deployed `0.6.4-beta54`, its first supervised
+card-driven Night Go, and the verified/deployed but uncommitted Night and Real
+Go follow-ups.
 
 ⚠️ Codex reads `AGENTS.md` by convention; this repo's instructions live in
 `CLAUDE.md`. The prompt below points at it explicitly, so no rename is needed —
@@ -19,8 +21,9 @@ LUBA robot mower to points clicked on a map, **with the blades OFF**. The goal i
 point-and-click movement, not mowing. It is at BETA; five acceptance gates are
 complete and Gate 5 has passed twice.
 
-Working directory is the repo root. Branch:
-`feat/beta31-reach-and-overshoot-ceiling`. `origin` is the **Chorty** fork —
+Working directory is the repo root. Branch: `main`; `HEAD`, `origin/main`, and
+`v0.6.4-beta54` agreed at `0bd35160` before the current working-tree changes.
+`origin` is the **Chorty** fork —
 `mikey0000/*` repositories are strictly read-only, never push or comment there.
 
 ## Read these first, in order
@@ -34,7 +37,7 @@ Working directory is the repo root. Branch:
 
 ## Your task
 
-The off-mower night implementation, beta52 deployment, and §7 items 15–18 are
+The off-mower night implementation, beta54 card control, and §7 items 15–18 are
 complete. Item 15 measured a −54.2208° quantum from one angular −500 / 1,500 ms
 refreshed pulse, then the first forward pulse exposed an 81.416° aim mismatch;
 the night guard stopped safely. Read
@@ -49,7 +52,29 @@ one 0.699963 m perpendicular segment, reached its 8° opening-turn tolerance,
 and stopped after three linear pulses on `no_target_progress` at 0.114277 m. It
 is characterization, not an acceptance pass; read
 `docs/night-segment-item18-20260814.md`. Item 15's separate mismatch remains
-unexplained. Until fresh authorization, further hardware work is read-only.
+unexplained.
+
+Beta54 subsequently ran one card-driven 0.739138 m Night Go. It reached heading
+tolerance after three turns, then stopped safely on `no_target_progress` at
+0.117085 m after three forward pulses. Pulse 2 was already only 0.082661 m from
+the target. A pre-pulse bearing was reused after the mower crossed the target,
+causing the unnecessary third pulse. Read
+`docs/night-go-card-beta54-20260814.md`.
+
+The working tree has uncommitted, unreleased night and Real Go fixes. Night
+calculates the residual bearing from settled post-pulse RTK and sends
+`sample_delays: [0, 3]` from the card/harness. Real Go now uses one four-second
+VIO-calibration feedback window, reuses settled linear telemetry instead of
+adding a three-second sample wait, and performs one final card reload. Its
+payload, mandatory stops, safety gates, legacy/night timing, and frozen profile
+values remain unchanged. One supervised Real Go run safely stopped before its
+second linear dispatch on `command_queue_backlogged`. The subsequent correction
+uses the existing bounded queue-settle check after VIO position feedback. A
+fresh supervised 0.70 m run reached its target in 19.2 s with 0.093100 m landing
+error; all three queue checks reached depth zero and all movement/stops
+succeeded. It is deployed motion-disabled after all six checks passed. Read
+`docs/real-go-throughput-hardware-20260814.md`. Until fresh authorization,
+hardware work is read-only.
 
 A same-day read-only autonomous-mow comparison then captured progressive
 `toward` changes through three vendor pivots. Read
@@ -60,8 +85,9 @@ specific to the bounded manual pulse/report cadence, not all rotation.
 
 1. **`LUBA_ACCEPTANCE_PROFILE` in `custom_components/mammotion/www/mammotion-custom-path-card.js` is FROZEN.**
    Changing any key's *value* un-accepts a hardware-accepted profile and obliges
-   a full re-pin plus a fresh acceptance gate. Night v1 makes **no card change at
-   all**.
+   a full re-pin plus a fresh acceptance gate. Night v1 did not change the card;
+   beta54 later added a separate Night Go control without changing any frozen
+   profile value.
 2. **Do not change behaviour on the VIO daylight path.** It passed Gate 5 twice.
    A `turn_mode: "vio"` run's dispatched payload and response fields must be
    byte-identical after your change.
@@ -112,15 +138,17 @@ npm run test:frontend
 .venv/bin/python -m pre_commit run --all-files
 ```
 
-Post-item-18 final results personally produced: **664 pytest, 39 frontend**, all six
-commands green. **Run them again after any change and report the counts you
+Current follow-up-tree results personally produced: **668 pytest, 46 frontend**,
+all six commands green. **Run them again after any change and report the counts you
 actually produced** — do not quote a number you did not
 generate. If something fails, paste the real traceback rather than summarising.
 
 ## Hardware — do not touch it
 
-The mower is real, outdoors, and currently docked and charging. A Home Assistant
-host at `192.168.1.106` runs the deployed build.
+The mower is real and outdoors. The last post-run sample was `(4.2954,
+-3.8079)`, `MODE_READY`, RTK Fix, blades off; do not treat that dated
+result as its current position. A Home Assistant host at `192.168.1.106` runs
+the corrected working tree motion-disabled.
 
 - **Do not enable experimental motion, do not arm the motion gate, and do not
   send any movement command.** Real motion requires explicit per-run
@@ -148,8 +176,8 @@ Your work is entirely off-mower: code, tests, and the CI gates above.
 
 ## What is genuinely unsettled — do not paper over these
 
-- Two closed-loop night-mode segments have run: item 15 stopped after its first
-  forward pulse, and item 18 stopped after three at 0.114277 m. Neither is a
+- Item 15, item 18, and the beta54 card-driven run have exercised the night
+  path. The latter two stopped at 0.114277 m and 0.117085 m. None is a
   landing-accuracy pass.
 - The mirror relation has now been used by one control loop and disagreed with
   the measured forward course. The cause is not yet established.

--- a/docs/CODEX-HANDOFF.md
+++ b/docs/CODEX-HANDOFF.md
@@ -1,9 +1,10 @@
 # Handoff — beta54 follow-ups deployed; corrected Real Go check passed
 
 `main`, `origin/main`, and tag `v0.6.4-beta54` agree at `0bd35160`. The clean,
-pushed branch `agent/night-real-go-followup` is at `801c1798`; draft PR #14
-targets `main`, with raw evidence isolated in commit `dd53e266`. Beta54 contains the guarded Night dry-run and
-Night Go card controls. It leaves `LUBA_ACCEPTANCE_PROFILE` unchanged and Real
+pushed branch `agent/night-real-go-followup` is draft PR #14. Raw evidence is
+isolated in commit `dd53e266`, implementation/tests in `801c1798`, and later
+commits only reconcile handoff docs. Beta54 contains the guarded Night dry-run
+and Night Go card controls. It leaves `LUBA_ACCEPTANCE_PROFILE` unchanged and Real
 Go remains `turn_mode: "vio"`. The beta54 motion-disabled install completed
 without a movement command. After the later supervised run, the motion gate was
 verified off with no active session.
@@ -21,8 +22,9 @@ still queued. The correction now runs the existing bounded queue-settle check
 after VIO feedback and records `post_feedback_queue_settle`; it never bypasses a
 persistent liveness fault. Final verification produced **668 pytest and 46
 frontend tests**; ruff check, ruff format check, mypy, and every pre-commit hook
-passed locally and in PR #14's Python/hassfest/Socket checks (HACS skipped). The corrected tree is deployed motion-disabled. A separately authorized
-0.70 m Real Go run then reached its target in 19.2 s with 0.093100 m landing
+passed locally and in PR #14's Python/hassfest/Socket checks (HACS skipped). The
+corrected tree is deployed motion-disabled. A separately authorized 0.70 m Real
+Go run then reached its target in 19.2 s with 0.093100 m landing
 error. All three new queue-settle records were live at depth zero, every
 movement/stop succeeded, and the gate was independently verified off. Read
 `docs/real-go-throughput-hardware-20260814.md`.

--- a/docs/CODEX-HANDOFF.md
+++ b/docs/CODEX-HANDOFF.md
@@ -1,13 +1,14 @@
 # Handoff — beta54 follow-ups deployed; corrected Real Go check passed
 
-`main`, `origin/main`, and tag `v0.6.4-beta54` agree at `0bd35160` before the
-current working-tree changes. Beta54 contains the guarded Night dry-run and
+`main`, `origin/main`, and tag `v0.6.4-beta54` agree at `0bd35160`. The clean,
+pushed branch `agent/night-real-go-followup` is at `801c1798`; draft PR #14
+targets `main`, with raw evidence isolated in commit `dd53e266`. Beta54 contains the guarded Night dry-run and
 Night Go card controls. It leaves `LUBA_ACCEPTANCE_PROFILE` unchanged and Real
 Go remains `turn_mode: "vio"`. The beta54 motion-disabled install completed
 without a movement command. After the later supervised run, the motion gate was
 verified off with no active session.
 
-The working tree now contains two uncommitted, unreleased changes plus tests.
+The PR branch contains two committed, unreleased changes plus tests.
 The night-only controller derives the residual bearing from settled post-pulse
 RTK, and the card/harness send `sample_delays: [0, 3]`. The Real Go throughput
 change uses one four-second VIO-calibration wait, reuses settled linear telemetry
@@ -20,7 +21,7 @@ still queued. The correction now runs the existing bounded queue-settle check
 after VIO feedback and records `post_feedback_queue_settle`; it never bypasses a
 persistent liveness fault. Final verification produced **668 pytest and 46
 frontend tests**; ruff check, ruff format check, mypy, and every pre-commit hook
-passed. The corrected tree is deployed motion-disabled. A separately authorized
+passed locally and in PR #14's Python/hassfest/Socket checks (HACS skipped). The corrected tree is deployed motion-disabled. A separately authorized
 0.70 m Real Go run then reached its target in 19.2 s with 0.093100 m landing
 error. All three new queue-settle records were live at depth zero, every
 movement/stop succeeded, and the gate was independently verified off. Read

--- a/docs/CODEX-HANDOFF.md
+++ b/docs/CODEX-HANDOFF.md
@@ -1,15 +1,30 @@
-# Handoff — beta52 night v1; items 15–18 measured and contained
+# Handoff — beta54 follow-ups deployed; corrected Real Go check passed
 
-Night v1 off-mower items 1–14 and the item-17 runtime diagnostics are deployed
-as `0.6.4-beta52`. Both card paths match md5
-`9512f504f4b861488e98f4d29ced6e4f`; Lovelace resource is
-`?v=0.6.4-beta52&build=9512f504`; `services.py` matches local md5
-`7c94607698ce6d9f55a4fd4a1a30f85f`; pymammotion is `0.8.12.post1`.
-Final integration verification produced 662 pytest and 39 frontend tests; ruff,
-format, mypy, and all pre-commit hooks passed. The acceptance-profile values
-were not changed. The motion gate read back `enabled: false`,
-`real_motion_allowed: false`, with no active session, and no movement command
-was sent during deployment.
+`main`, `origin/main`, and tag `v0.6.4-beta54` agree at `0bd35160` before the
+current working-tree changes. Beta54 contains the guarded Night dry-run and
+Night Go card controls. It leaves `LUBA_ACCEPTANCE_PROFILE` unchanged and Real
+Go remains `turn_mode: "vio"`. The beta54 motion-disabled install completed
+without a movement command. After the later supervised run, the motion gate was
+verified off with no active session.
+
+The working tree now contains two uncommitted, unreleased changes plus tests.
+The night-only controller derives the residual bearing from settled post-pulse
+RTK, and the card/harness send `sample_delays: [0, 3]`. The Real Go throughput
+change uses one four-second VIO-calibration wait, reuses settled linear telemetry
+instead of adding a three-second sampling wait, and removes a duplicate final
+card reload. Its dispatched payload, mandatory stops, safety gates, legacy/night
+timing, and frozen profile values are unchanged; the VIO result adds explicit
+settled-feedback provenance. The first supervised Real Go check safely refused
+its second linear command before dispatch because feedback report requests were
+still queued. The correction now runs the existing bounded queue-settle check
+after VIO feedback and records `post_feedback_queue_settle`; it never bypasses a
+persistent liveness fault. Final verification produced **668 pytest and 46
+frontend tests**; ruff check, ruff format check, mypy, and every pre-commit hook
+passed. The corrected tree is deployed motion-disabled. A separately authorized
+0.70 m Real Go run then reached its target in 19.2 s with 0.093100 m landing
+error. All three new queue-settle records were live at depth zero, every
+movement/stop succeeded, and the gate was independently verified off. Read
+`docs/real-go-throughput-hardware-20260814.md`.
 
 Plan §7 item 15 is complete. The one night-branch turn pulse measured −54.2208°
 at angular −500 / 1,500 ms / six 200 ms refresh writes, with 0.07459 m turn
@@ -46,10 +61,21 @@ mirror observations were 92.0720 / 90.7417 / 89.1569°. Raw evidence is commit
 The item-18 harness-only safety pins raised the final full-suite count to 664
 pytest; frontend remained 39 and ruff, format, mypy, and pre-commit were green.
 
-The gate is off, no session is active, the mower is `MODE_READY`, RTK Fix, BLE
-live, and blades zero. Item 15's separate forward-course mismatch remains
-unexplained. Every further physical run needs
-fresh explicit supervised-motion authorization.
+After beta54, one supervised card-driven Night Go requested 0.739138 m from
+`(4.954, -2.643)` to `(5.692, -2.602)`. Three turns reached 3.3962° heading
+error. The first two forward pulses settled 0.225639 m and 0.082661 m from the
+target. Because the continuation decision reused the pre-pulse bearing, it sent
+a third pulse after crossing the target and stopped safely on
+`no_target_progress` at 0.117085 m. See
+`docs/night-go-card-beta54-20260814.md` and
+`docs/evidence-night-go-card-beta54-20260814T180345Z.json`. This is
+characterization, not night accuracy acceptance.
+
+The corrected run's final telemetry measured `(4.2954, -3.8079)`, gate off, no
+active session, `MODE_READY`, RTK Fix, BLE live, and blades zero. That is a
+dated result, not authorization or a claim of present physical state. Item 15's separate forward-course mismatch
+remains unexplained. Every further physical run needs fresh explicit
+supervised-motion authorization.
 
 ---
 

--- a/docs/NEXT-SESSION.md
+++ b/docs/NEXT-SESSION.md
@@ -12,11 +12,11 @@ measurements stand — but do not act on any build/host/gate state they describe
 
 | | |
 | --- | --- |
-| Branch | `agent/night-real-go-followup` at `801c1798`, pushed to Chorty; draft PR #14 targets `main` at beta54 `0bd35160` |
+| Branch | `agent/night-real-go-followup`, clean and pushed to Chorty; draft PR #14 targets `main` at beta54 `0bd35160` |
 | Released version | `0.6.4-beta54`; manifest, pyproject, card, and lock version sites agree |
-| Working tree | Clean. Evidence commit `dd53e266`, implementation/tests/docs commit `801c1798`; corrected tree is deployed but unreleased |
+| Working tree | Clean. Evidence commit `dd53e266`, implementation/tests commit `801c1798`, followed only by handoff-doc commits; corrected code is deployed but unreleased |
 | Motion gate | ✅ **DISARMED.** `real_motion_allowed: false`, no active session |
-| Last measured mower state | Post-redeploy read-only preflight: `(4.7113, -3.3620)`, `MODE_READY`, BLE −64 dBm, RTK Fix, VIO Light/80, blades zero. This is a dated result, not a claim of current physical position. |
+| Last measured mower state | End of corrected Real Go check: `(4.2954, -3.8079)`, `MODE_READY`, BLE −64 dBm, RTK Fix, blades zero. Gate independently disarmed. This is a dated result, not a claim of current physical position. |
 
 ## 1. What to do next
 

--- a/docs/NEXT-SESSION.md
+++ b/docs/NEXT-SESSION.md
@@ -12,9 +12,9 @@ measurements stand — but do not act on any build/host/gate state they describe
 
 | | |
 | --- | --- |
-| Branch | `main`; `HEAD`, `origin/main`, and `v0.6.4-beta54` agree at `0bd35160` before the current working-tree changes |
+| Branch | `agent/night-real-go-followup` at `801c1798`, pushed to Chorty; draft PR #14 targets `main` at beta54 `0bd35160` |
 | Released version | `0.6.4-beta54`; manifest, pyproject, card, and lock version sites agree |
-| Working tree | Uncommitted night and VIO-only Real Go throughput fixes, tests, and hardware evidence; corrected tree is deployed but unreleased |
+| Working tree | Clean. Evidence commit `dd53e266`, implementation/tests/docs commit `801c1798`; corrected tree is deployed but unreleased |
 | Motion gate | ✅ **DISARMED.** `real_motion_allowed: false`, no active session |
 | Last measured mower state | Post-redeploy read-only preflight: `(4.7113, -3.3620)`, `MODE_READY`, BLE −64 dBm, RTK Fix, VIO Light/80, blades zero. This is a dated result, not a claim of current physical position. |
 
@@ -65,8 +65,8 @@ away from a target already behind it. See
 reached its target in 19.2 s with 0.093100 m landing error. All three
 post-feedback queue-settle checks reached depth zero in about 100–101 ms and
 every movement/stop succeeded. The gate was independently verified off after
-the run. Next software action: review and publish the currently uncommitted
-corrections. The night change recomputes the residual target bearing from the
+the run. Next software action: review and merge draft PR #14, then prepare the
+next beta. The night change recomputes the residual target bearing from the
 settled post-pulse RTK position, so the existing reverse-recovery refusal can
 stop the crossed-target case. The card/harness set `sample_delays: [0, 3]` to
 replace beta54's inherited 0/5/10/20/30/45/60-second waits. Real Go now avoids
@@ -145,9 +145,9 @@ npm run test:frontend
 .venv/bin/python -m pre_commit run --all-files
 ```
 
-There is **no global `uv`** — use `.venv/bin/python` directly. The current
-uncommitted follow-up tree personally produced **668 pytest, 46 frontend**, all
-six commands green. Run them again after later changes; do not carry these
+There is **no global `uv`** — use `.venv/bin/python` directly. PR #14's code
+commit personally produced **668 pytest, 46 frontend**, all six commands green;
+its Python, hassfest, and Socket GitHub checks also passed. Run them again after later changes; do not carry these
 counts forward as if newly measured.
 
 ## 4. Hardware rules — non-negotiable

--- a/docs/NEXT-SESSION.md
+++ b/docs/NEXT-SESSION.md
@@ -6,21 +6,21 @@ measurements stand — but do not act on any build/host/gate state they describe
 
 ---
 
-# 🚦 2026-08-13 HANDOFF — read this section, then the plan it points to
+# 🚦 2026-08-14 HANDOFF — beta54 Night Go and local follow-up
 
-## 0. Live state, verified 2026-08-14 after item 18
+## 0. Live state, verified 2026-08-14 after the beta54 card run
 
 | | |
 | --- | --- |
-| Branch | `feat/beta31-reach-and-overshoot-ceiling`, publish target `origin` = the **Chorty** fork |
-| Version | `0.6.4-beta52` — host and branch agree; manifest, pyproject, card and lock version sites agree |
-| Card on host | md5 `9512f504f4b861488e98f4d29ced6e4f`, identical at **both** serving paths; resource `?v=0.6.4-beta52&build=9512f504` |
+| Branch | `main`; `HEAD`, `origin/main`, and `v0.6.4-beta54` agree at `0bd35160` before the current working-tree changes |
+| Released version | `0.6.4-beta54`; manifest, pyproject, card, and lock version sites agree |
+| Working tree | Uncommitted night and VIO-only Real Go throughput fixes, tests, and hardware evidence; corrected tree is deployed but unreleased |
 | Motion gate | ✅ **DISARMED.** `real_motion_allowed: false`, no active session |
-| Mower | Post-run readback: `MODE_READY`, BLE live at −58 dBm, RTK Fix, blades zero |
+| Last measured mower state | Post-redeploy read-only preflight: `(4.7113, -3.3620)`, `MODE_READY`, BLE −64 dBm, RTK Fix, VIO Light/80, blades zero. This is a dated result, not a claim of current physical position. |
 
 ## 1. What to do next
 
-✅ **Night v1 is implemented; item-17 diagnostics are deployed as beta52.** It adds an
+✅ **Night v1 is implemented and beta54 adds a guarded card control.** The backend adds an
 explicit `turn_mode: "night"` for one forward-only segment, night-only mirror
 conversion, angular 500 with refresh, fixed-budget/RTK/length/heading/re-aim/
 reverse/multi-segment refusals, and the `--night-segment` harness mode. The
@@ -54,6 +54,32 @@ then used all three linear commands and stopped on `no_target_progress` at
 89.1569°. Read `docs/night-segment-item18-20260814.md` and the raw evidence it
 links. The run does not establish a night tolerance or landing distribution.
 
+✅ **A beta54 card-driven Night Go is also measured.** The 0.739138 m requested
+leg reached its opening heading after three turns. It used three forward pulses
+and stopped safely on `no_target_progress` at 0.117085 m. After pulse 2 it was
+only 0.082661 m away, 0.002661 m outside the configured tolerance; pulse 3 moved
+away from a target already behind it. See
+`docs/night-go-card-beta54-20260814.md` and its linked complete JSON.
+
+✅ **The corrected Real Go check passed.** The separately authorized 0.70 m run
+reached its target in 19.2 s with 0.093100 m landing error. All three
+post-feedback queue-settle checks reached depth zero in about 100–101 ms and
+every movement/stop succeeded. The gate was independently verified off after
+the run. Next software action: review and publish the currently uncommitted
+corrections. The night change recomputes the residual target bearing from the
+settled post-pulse RTK position, so the existing reverse-recovery refusal can
+stop the crossed-target case. The card/harness set `sample_delays: [0, 3]` to
+replace beta54's inherited 0/5/10/20/30/45/60-second waits. Real Go now avoids
+additive calibration/linear feedback waits and one duplicate card reload while
+preserving its payload, stops, gates, and frozen profile values. The first
+hardware run safely refused its second linear command on
+`command_queue_backlogged`; the correction now explicitly settles that queue
+after feedback and refuses without dispatch if it remains non-live. The final
+local tree produced **668 pytest and 46 frontend tests**, with all six
+verification commands green. It is deployed motion-disabled and hardware-tested,
+but not released. Read
+`docs/real-go-throughput-hardware-20260814.md`.
+
 ⚠️ Item 15's 14.3069° mirror observation remains unexplained, although item 18's
 three observations near 90.13° show it is not stable across all night pulses.
 The latency result does not explain that mismatch because the executor waits
@@ -67,7 +93,7 @@ pivots. `toward` streamed progressively during those continuous vendor turns;
 item 16's single post-pulse update characterizes our bounded pulse/report path,
 not all mower rotation. See `docs/autonomous-mow-observation-20260813.md`.
 
-It was produced by a 20-agent adversarial design workflow and **every gate design
+The original plan was produced by a 20-agent adversarial design workflow and **every gate design
 in it was refuted at least once before the plan was written**. Read §4 before
 changing anything — it records 21 defects already fixed and 8 risks knowingly
 accepted, so a "fix" you invent may already have been considered and rejected.
@@ -95,7 +121,8 @@ runaway-safety claim is **wrong**; the banner at its top says so.
    avoids this by scoping the mirror to `turn_mode: "night"` only.
 3. **`LUBA_ACCEPTANCE_PROFILE` (card JS) is frozen.** Changing any key's *value*
    un-accepts a twice-Gate-5-passed profile and owes a re-pin plus a fresh Gate 5.
-   Night v1 deliberately makes **no card change at all**.
+   Night v1 did not change it. Beta54 later added a separate Night Go card
+   control while leaving every frozen profile value intact.
 4. **The card is served from TWO paths.** Deploy to both and bump the Lovelace
    resource key, or the browser silently loads the stale card.
    ⚠️ `scripts/ha_set_card_resource.py` does **not** append the `build=` suffix —
@@ -118,10 +145,10 @@ npm run test:frontend
 .venv/bin/python -m pre_commit run --all-files
 ```
 
-There is **no global `uv`** — use `.venv/bin/python` directly. Beta50 counts
-personally produced on the final tree: **658 pytest, 39 frontend**, all six
-commands green. Run them again before a later change; do not carry these counts
-forward as if newly measured.
+There is **no global `uv`** — use `.venv/bin/python` directly. The current
+uncommitted follow-up tree personally produced **668 pytest, 46 frontend**, all
+six commands green. Run them again after later changes; do not carry these
+counts forward as if newly measured.
 
 ## 4. Hardware rules — non-negotiable
 
@@ -136,14 +163,16 @@ forward as if newly measured.
   "Download last run JSON" button for exactly this.
 - Blades OFF. This project never runs blades-on — the goal is point-and-click
   movement, not mowing.
-- Night-mode turns work without VIO. Two bounded night-mode segments have run;
-  neither establishes a night landing-accuracy specification.
+- Night-mode turns work without VIO. Item 15, item 18, and one beta54
+  card-driven Night Go have run; none establishes a night landing-accuracy
+  specification.
 
 ## 5. What is genuinely unsettled
 
-- Two closed-loop night-mode segments have run. Item 15 stopped after one pulse
-  on `night_reaim_required_but_unavailable`; item 18 stopped after three pulses
-  on `no_target_progress` at 0.114277 m. Neither is a landing-accuracy pass.
+- Three night-path characterizations have run. Item 15 stopped after one pulse
+  on `night_reaim_required_but_unavailable`; item 18 stopped at 0.114277 m; the
+  beta54 card run stopped at 0.117085 m and exposed the stale pre-pulse-bearing
+  decision. None is a landing-accuracy pass.
 - The mirror has now been consumed by one control loop and disagreed with the
   measured forward course by 75.823° (`movement bearing + toward` was 14.3069°
   rather than 90.13°). Cause remains unknown.

--- a/docs/deploy-runbook-p0.md
+++ b/docs/deploy-runbook-p0.md
@@ -19,8 +19,8 @@ One later, separately authorized card-driven night run stopped safely at
 0.117085 m on `no_target_progress`. The motion gate was disarmed afterward. See
 `night-go-card-beta54-20260814.md`. The run exposed a night-only crossed-target
 continuation defect and excessive diagnostic waits. The deployed branch
-contains a verified fix in draft PR #14 (`agent/night-real-go-followup` at
-`801c1798`), and the Real Go path removes additive
+contains a verified fix in draft PR #14 (`agent/night-real-go-followup`; code
+commit `801c1798`), and the Real Go path removes additive
 feedback waits while preserving its payload and safety gates. The first
 supervised Real Go check stopped before its second linear dispatch on
 `command_queue_backlogged`. A bounded post-feedback queue-settle correction was

--- a/docs/deploy-runbook-p0.md
+++ b/docs/deploy-runbook-p0.md
@@ -18,8 +18,9 @@ in `LUBA_ACCEPTANCE_PROFILE`, and Real Go remains the accepted VIO path.
 One later, separately authorized card-driven night run stopped safely at
 0.117085 m on `no_target_progress`. The motion gate was disarmed afterward. See
 `night-go-card-beta54-20260814.md`. The run exposed a night-only crossed-target
-continuation defect and excessive diagnostic waits. The current working tree
-contains a verified but uncommitted fix, and the Real Go path removes additive
+continuation defect and excessive diagnostic waits. The deployed branch
+contains a verified fix in draft PR #14 (`agent/night-real-go-followup` at
+`801c1798`), and the Real Go path removes additive
 feedback waits while preserving its payload and safety gates. The first
 supervised Real Go check stopped before its second linear dispatch on
 `command_queue_backlogged`. A bounded post-feedback queue-settle correction was

--- a/docs/deploy-runbook-p0.md
+++ b/docs/deploy-runbook-p0.md
@@ -1,17 +1,53 @@
 # P0 deploy and rollback runbook (host 192.168.1.106)
 
-First deployed 2026-07-29 and updated through the 2026-08-06 beta22 containment
-deploy. For
+First deployed 2026-07-29 and updated through the 2026-08-14 corrected
+working-tree deploy after the beta54 Night Go release. For
 any later deploy, work while the mower is stopped and experimental motion is
 off. Restarting HA while BLE is unhealthy has previously left the integration
 in `setup_error` with no auto-retry, needing a manual entry reload.
 
 ## What the host is running now
 
+### beta54 plus unreleased Night/Real Go corrections — 2026-08-14
+
+`0.6.4-beta54` was published from merge commit `2573c29b` and version commit
+`0bd35160`, then installed with experimental motion disabled. The release adds
+separate Night dry-run and Night Go card controls; it does not change any value
+in `LUBA_ACCEPTANCE_PROFILE`, and Real Go remains the accepted VIO path.
+
+One later, separately authorized card-driven night run stopped safely at
+0.117085 m on `no_target_progress`. The motion gate was disarmed afterward. See
+`night-go-card-beta54-20260814.md`. The run exposed a night-only crossed-target
+continuation defect and excessive diagnostic waits. The current working tree
+contains a verified but uncommitted fix, and the Real Go path removes additive
+feedback waits while preserving its payload and safety gates. The first
+supervised Real Go check stopped before its second linear dispatch on
+`command_queue_backlogged`. A bounded post-feedback queue-settle correction was
+then verified and deployed motion-disabled. These working-tree behaviors are
+**not** part of the beta54 release artifact. Full evidence and measured/inferred
+separation: `real-go-throughput-hardware-20260814.md`.
+
+Backup `/config/mammotion-backup-20260814-pre-queue-settle.tgz`; archive SHA-256
+`ec46d8fb0fce6aefcf7b2032c88a17b0693cf14cdd5bce086fb9396da5674b5d`.
+Host MD5s match local: services `d6ab89ff4e4286b33d4fa5755bba5b0d`, card
+`4846aa9b6f9e0eefe67cb95f8326c3ba` at both serving paths, manifest
+`ef8d5273c8e9730bc964579efb63116a`. API returned after 30 s and 132 Mammotion
+entities after 116 s; container pymammotion is `0.8.12.post1`. Final gate
+readback: disabled, `real_motion_allowed: false`, no active session,
+`MODE_READY`.
+
+One separately authorized corrected Real Go run then reached the 0.70 m target
+in 19.2 s with 0.093100 m landing error. It used zero turns and three forward
+pulses. The new per-pulse queue-settle records were all live at depth zero in
+about 100–101 ms; all movement commands and stops succeeded. Final telemetry
+was `(4.2954, -3.8079)`, RTK Fix, `MODE_READY`, BLE −64 dBm, blades off. The
+gate was independently verified disabled with no active session. Evidence:
+`real-go-throughput-hardware-20260814.md` and its linked raw JSON.
+
 ### beta52 — item-17 runtime diagnostics, 2026-08-13
 
-`0.6.4-beta52` is deployed. It adds runtime-export-only RapidState diagnostics
-and the fixed backward-only item-17 harness; it does not add the diagnostics to
+`0.6.4-beta52` was deployed. It added runtime-export-only RapidState diagnostics
+and the fixed backward-only item-17 harness; it did not add the diagnostics to
 shared VIO telemetry. Backup:
 `/config/mammotion-backup-20260813-beta52-predeploy.tgz`. The deployed archive
 matched local md5 `efa589bc7eaa6bf72e065529f7d44369`. Card md5

--- a/docs/evidence-beta32-4segment-20260814T202705Z.json
+++ b/docs/evidence-beta32-4segment-20260814T202705Z.json
@@ -1,0 +1,1642 @@
+{
+ "valid": true,
+ "errors": [],
+ "warnings": [],
+ "coordinate_system": "mower_map_xy",
+ "blade_mode": "off",
+ "speed": 0.2,
+ "area_hash": null,
+ "point_count": 2,
+ "distance": 0.7000357133746818,
+ "points": [
+  {
+   "x": 5.0068,
+   "y": -3.0411
+  },
+  {
+   "x": 4.5118,
+   "y": -3.5361
+  }
+ ],
+ "geojson": {
+  "type": "FeatureCollection",
+  "features": [
+   {
+    "type": "Feature",
+    "properties": {
+     "type_name": "custom_path_start",
+     "Name": "Start",
+     "marker": "start"
+    },
+    "geometry": {
+     "type": "Point",
+     "coordinates": [
+      5.0068,
+      -3.0411
+     ]
+    }
+   },
+   {
+    "type": "Feature",
+    "properties": {
+     "type_name": "custom_path",
+     "Name": "Custom path",
+     "valid": true,
+     "distance": 0.7000357133746818,
+     "color": "#22c55e",
+     "weight": 3
+    },
+    "geometry": {
+     "type": "LineString",
+     "coordinates": [
+      [
+       5.0068,
+       -3.0411
+      ],
+      [
+       4.5118,
+       -3.5361
+      ]
+     ]
+    }
+   },
+   {
+    "type": "Feature",
+    "properties": {
+     "type_name": "custom_path_end",
+     "Name": "End",
+     "marker": "end"
+    },
+    "geometry": {
+     "type": "Point",
+     "coordinates": [
+      4.5118,
+      -3.5361
+     ]
+    }
+   }
+  ]
+ },
+ "path": {
+  "coordinate_system": "mower_map_xy",
+  "points": [
+   {
+    "x": 5.0068,
+    "y": -3.0411
+   },
+   {
+    "x": 4.5118,
+    "y": -3.5361
+   }
+  ],
+  "distance": 0.7000357133746818
+ },
+ "service": "raw_pymammotion_execute_multi_segment",
+ "mode": "real_raw_multi_segment",
+ "dry_run": false,
+ "would_send": true,
+ "real_execution_scope": "guarded_multi_segment_vector_chain",
+ "full_path_execution_allowed": false,
+ "ready_for_multi_point": false,
+ "ready_for_multi_segment": false,
+ "initial_vio_feed": {
+  "live": true,
+  "tracked_features": 80,
+  "brightness_raw": 1,
+  "brightness_label": "Light"
+ },
+ "prefer_ble": true,
+ "transport_preference": "ble_preferred",
+ "ble_auto_recover": false,
+ "ble_recovery": null,
+ "max_real_segments": 1,
+ "max_turn_commands": 4,
+ "max_linear_commands": 3,
+ "linear_speed_fast": 400,
+ "linear_speed_slow": 200,
+ "slow_linear_threshold": 0.15,
+ "heading_tolerance_degrees": 18.0,
+ "angular_speed_fast": 180,
+ "angular_speed_slow": 180,
+ "slow_turn_threshold_degrees": 8.0,
+ "waypoint_tolerance": 0.15,
+ "min_progress_distance": 0.0025,
+ "min_heading_change_degrees": 0.5,
+ "max_turn_translation_distance": 0.3,
+ "calibrated_forward_heading_offset_degrees": 102.4,
+ "turn_mode": "vio",
+ "vio_heading_offset_degrees": null,
+ "turn_pulse_duration_ms": 1500.0,
+ "linear_pulse_duration_ms": 1300.0,
+ "final_approach_metres_per_pulse": 1.06,
+ "turn_degrees_per_second": 37.0,
+ "vio_turn_max_commands": 4,
+ "vio_angular_speed": 500,
+ "max_linear_pulse_ceiling": 14,
+ "max_no_progress_pulses": 3,
+ "motion_refresh_interval_ms": 200,
+ "sample_delays": [
+  0.0,
+  3.0
+ ],
+ "confirm_blades_off": true,
+ "confirm_clear_area": true,
+ "total_segments": 1,
+ "segments_planned": 1,
+ "segments_executed": 1,
+ "real_segments_executed": 1,
+ "segments": [
+  {
+   "index": 1,
+   "points": [
+    {
+     "x": 5.0068,
+     "y": -3.0411
+    },
+    {
+     "x": 4.5118,
+     "y": -3.5361
+    }
+   ],
+   "real_segment": true,
+   "passed": false,
+   "result": {
+    "valid": true,
+    "errors": [],
+    "warnings": [],
+    "coordinate_system": "mower_map_xy",
+    "blade_mode": "off",
+    "speed": 0.2,
+    "area_hash": null,
+    "point_count": 2,
+    "distance": 0.7000357133746818,
+    "points": [
+     {
+      "x": 5.0068,
+      "y": -3.0411
+     },
+     {
+      "x": 4.5118,
+      "y": -3.5361
+     }
+    ],
+    "geojson": {
+     "type": "FeatureCollection",
+     "features": [
+      {
+       "type": "Feature",
+       "properties": {
+        "type_name": "custom_path_start",
+        "Name": "Start",
+        "marker": "start"
+       },
+       "geometry": {
+        "type": "Point",
+        "coordinates": [
+         5.0068,
+         -3.0411
+        ]
+       }
+      },
+      {
+       "type": "Feature",
+       "properties": {
+        "type_name": "custom_path",
+        "Name": "Custom path",
+        "valid": true,
+        "distance": 0.7000357133746818,
+        "color": "#22c55e",
+        "weight": 3
+       },
+       "geometry": {
+        "type": "LineString",
+        "coordinates": [
+         [
+          5.0068,
+          -3.0411
+         ],
+         [
+          4.5118,
+          -3.5361
+         ]
+        ]
+       }
+      },
+      {
+       "type": "Feature",
+       "properties": {
+        "type_name": "custom_path_end",
+        "Name": "End",
+        "marker": "end"
+       },
+       "geometry": {
+        "type": "Point",
+        "coordinates": [
+         4.5118,
+         -3.5361
+        ]
+       }
+      }
+     ]
+    },
+    "path": {
+     "coordinate_system": "mower_map_xy",
+     "points": [
+      {
+       "x": 5.0068,
+       "y": -3.0411
+      },
+      {
+       "x": 4.5118,
+       "y": -3.5361
+      }
+     ],
+     "distance": 0.7000357133746818
+    },
+    "service": "raw_pymammotion_execute_vector_segment",
+    "mode": "real_raw_vector_segment",
+    "dry_run": false,
+    "would_send": true,
+    "real_execution_scope": "one_segment_turn_then_forward_only",
+    "full_path_execution_allowed": false,
+    "ready_for_multi_point": false,
+    "prefer_ble": true,
+    "transport_preference": "ble_preferred",
+    "ble_auto_recover": false,
+    "ble_recovery": null,
+    "linear_speed_fast": 400,
+    "linear_speed_slow": 200,
+    "slow_linear_threshold": 0.15,
+    "max_turn_commands": 4,
+    "max_linear_commands": 3,
+    "heading_tolerance_degrees": 18.0,
+    "angular_speed_fast": 180,
+    "angular_speed_slow": 180,
+    "slow_turn_threshold_degrees": 8.0,
+    "waypoint_tolerance": 0.15,
+    "min_progress_distance": 0.0025,
+    "min_heading_change_degrees": 0.5,
+    "max_turn_translation_distance": 0.3,
+    "calibrated_forward_heading_offset_degrees": 102.4,
+    "max_linear_pulse_ceiling": 14,
+    "max_no_progress_pulses": 3,
+    "final_approach_metres_per_pulse": 1.06,
+    "turn_degrees_per_second": 37.0,
+    "turn_pulse_duration_ms": 1500.0,
+    "linear_pulse_duration_ms": 1300.0,
+    "vio_turn_max_commands": 4,
+    "vio_angular_speed": 500,
+    "vio_heading_offset_degrees": null,
+    "sample_delays": [
+     0.0,
+     3.0
+    ],
+    "confirm_blades_off": true,
+    "confirm_clear_area": true,
+    "advisory_start": {
+     "x": 5.0068,
+     "y": -3.0411
+    },
+    "true_start": {
+     "x": 5.0068,
+     "y": -3.0411
+    },
+    "target": {
+     "x": 4.5118,
+     "y": -3.5361
+    },
+    "target_map_heading_degrees": 224.4756718351794,
+    "target_reported_heading_degrees": 122.59999999999997,
+    "target_heading_degrees": 122.59999999999997,
+    "heading_calibration": {
+     "formula": "target_reported_heading = target_map_heading - calibrated_forward_heading_offset",
+     "target_map_heading_degrees": 224.99999999999997,
+     "calibrated_forward_heading_offset_degrees": 102.4,
+     "target_reported_heading_degrees": 122.59999999999997
+    },
+    "initial_linear_command_selection": {
+     "command": "send_movement",
+     "linear_speed": 400,
+     "angular_speed": 0,
+     "distance_to_target": 0.7000357133746818,
+     "speed_tier": "fast",
+     "slow_linear_threshold": 0.15,
+     "reason": "target_remaining"
+    },
+    "turn_mode": "vio",
+    "vio": {
+     "initial_vio_state": 2,
+     "initial_vio_feed": {
+      "live": true,
+      "tracked_features": 80,
+      "brightness_raw": 1,
+      "brightness_label": "Light"
+     },
+     "initial_vision_heading": -132.85646599110186,
+     "provided_offset_degrees": null,
+     "offset_degrees": 359.36583920325563,
+     "offset_source": "linear_refresh",
+     "target_vision_heading": 222.1412329668437,
+     "calibration": {
+      "passed": true,
+      "reason": "calibrated",
+      "offset_degrees": 2.334438868335724,
+      "map_motion_heading_degrees": 229.415,
+      "vision_heading": -132.91902676953242,
+      "vio_state": 2,
+      "vio_feed": {
+       "live": true,
+       "tracked_features": 80,
+       "brightness_raw": 1,
+       "brightness_label": "Light"
+      },
+      "distance_m": 0.0743963036716205,
+      "pulses_sent": 1,
+      "command_results": [
+       {
+        "index": 1,
+        "phase": "vio_calibration_drive",
+        "command": "send_movement",
+        "kwargs": {
+         "linear_speed": 400,
+         "angular_speed": 0
+        },
+        "sent_at_utc": "2026-08-14T20:27:06.003212+00:00",
+        "ok": true,
+        "error": null,
+        "stop_result": {
+         "attempted": true,
+         "ok": true,
+         "error": null,
+         "coordinator_method": "async_stop_manual_motion",
+         "use_wifi": false,
+         "transport_preference": "ble_preferred",
+         "ack": {
+          "movement_ok": true
+         },
+         "duration_ms": 75.016
+        },
+        "feedback_refresh": {
+         "method": "request_reports_count_5",
+         "settle_seconds": 0.0,
+         "ok": true,
+         "error": null,
+         "duration_ms": 0.445
+        }
+       }
+      ]
+     },
+     "formula": "target_vision_heading = target_map_heading - (map_motion_heading - vision_heading)"
+    },
+    "initial_telemetry": {
+     "online": true,
+     "work_mode": 11,
+     "work_mode_label": "MODE_READY",
+     "charge_state": 0,
+     "charge_state_label": "not_charging",
+     "position": {
+      "x": 5.0068,
+      "y": -3.0411,
+      "toward": -136.5265,
+      "source": "report_data.locations[0]",
+      "pos_level": 1,
+      "pos_level_label": "SINGLE",
+      "rtk_status": 4,
+      "rtk_status_label": "Fix",
+      "pos_type": 1,
+      "pos_type_label": "AREA_INSIDE",
+      "zone_hash": "1343645155037768237",
+      "map_bol_hash": "3192426378327374167",
+      "area_name": "Backyard Right",
+      "valid_for_motion": true
+     },
+     "position_candidates": [
+      {
+       "source": "mowing_state",
+       "x": 0.0,
+       "y": 0.0,
+       "toward": 0.0,
+       "pos_level": 0,
+       "pos_level_label": "FIX",
+       "rtk_status": 0,
+       "rtk_status_label": "None",
+       "pos_type": 0,
+       "pos_type_label": "AREA_OUT",
+       "zone_hash": 0,
+       "area_name": null,
+       "stale_zero_area_out": true,
+       "valid_for_motion": false
+      },
+      {
+       "source": "report_data.locations[0]",
+       "x": 5.0068,
+       "y": -3.0411,
+       "toward": -136.5265,
+       "pos_level": null,
+       "pos_level_label": null,
+       "rtk_status": null,
+       "rtk_status_label": null,
+       "pos_type": 1,
+       "pos_type_label": "AREA_INSIDE",
+       "zone_hash": null,
+       "area_name": null,
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      },
+      {
+       "source": "location_metadata",
+       "x": null,
+       "y": null,
+       "toward": -136,
+       "pos_level": null,
+       "pos_level_label": null,
+       "rtk_status": null,
+       "rtk_status_label": null,
+       "pos_type": 1,
+       "pos_type_label": "AREA_INSIDE",
+       "zone_hash": "1343645155037768237",
+       "area_name": "Backyard Right",
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      },
+      {
+       "source": "report_data.rtk",
+       "x": null,
+       "y": null,
+       "toward": null,
+       "pos_level": 1,
+       "pos_level_label": "SINGLE",
+       "rtk_status": 4,
+       "rtk_status_label": "Fix",
+       "pos_type": null,
+       "pos_type_label": null,
+       "zone_hash": null,
+       "area_name": null,
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      }
+     ],
+     "blade": {
+      "reported_state": 0,
+      "reported_state_label": "OFF",
+      "knife_status": null,
+      "current_cutter_mode": 0,
+      "current_cutter_rpm": 0
+     },
+     "transport": {
+      "ble_rssi": -68,
+      "wifi_rssi": -51,
+      "wifi_connect_status": null,
+      "iot_connect_status": null,
+      "connection_label": "WIFI/BLE"
+     }
+    },
+    "final_telemetry": {
+     "online": true,
+     "work_mode": 11,
+     "work_mode_label": "MODE_READY",
+     "charge_state": 0,
+     "charge_state_label": "not_charging",
+     "position": {
+      "x": 4.714,
+      "y": -3.3575,
+      "toward": -136.5265,
+      "source": "report_data.locations[0]",
+      "pos_level": 1,
+      "pos_level_label": "SINGLE",
+      "rtk_status": 4,
+      "rtk_status_label": "Fix",
+      "pos_type": 1,
+      "pos_type_label": "AREA_INSIDE",
+      "zone_hash": "1343645155037768237",
+      "map_bol_hash": "3192426378327374167",
+      "area_name": "Backyard Right",
+      "valid_for_motion": true
+     },
+     "position_candidates": [
+      {
+       "source": "mowing_state",
+       "x": 0.0,
+       "y": 0.0,
+       "toward": 0.0,
+       "pos_level": 0,
+       "pos_level_label": "FIX",
+       "rtk_status": 0,
+       "rtk_status_label": "None",
+       "pos_type": 0,
+       "pos_type_label": "AREA_OUT",
+       "zone_hash": 0,
+       "area_name": null,
+       "stale_zero_area_out": true,
+       "valid_for_motion": false
+      },
+      {
+       "source": "report_data.locations[0]",
+       "x": 4.714,
+       "y": -3.3575,
+       "toward": -136.5265,
+       "pos_level": null,
+       "pos_level_label": null,
+       "rtk_status": null,
+       "rtk_status_label": null,
+       "pos_type": 1,
+       "pos_type_label": "AREA_INSIDE",
+       "zone_hash": null,
+       "area_name": null,
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      },
+      {
+       "source": "location_metadata",
+       "x": null,
+       "y": null,
+       "toward": -136,
+       "pos_level": null,
+       "pos_level_label": null,
+       "rtk_status": null,
+       "rtk_status_label": null,
+       "pos_type": 1,
+       "pos_type_label": "AREA_INSIDE",
+       "zone_hash": "1343645155037768237",
+       "area_name": "Backyard Right",
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      },
+      {
+       "source": "report_data.rtk",
+       "x": null,
+       "y": null,
+       "toward": null,
+       "pos_level": 1,
+       "pos_level_label": "SINGLE",
+       "rtk_status": 4,
+       "rtk_status_label": "Fix",
+       "pos_type": null,
+       "pos_type_label": null,
+       "zone_hash": null,
+       "area_name": null,
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      }
+     ],
+     "blade": {
+      "reported_state": 0,
+      "reported_state_label": "OFF",
+      "knife_status": null,
+      "current_cutter_mode": 0,
+      "current_cutter_rpm": 0
+     },
+     "transport": {
+      "ble_rssi": -66,
+      "wifi_rssi": -51,
+      "wifi_connect_status": null,
+      "iot_connect_status": null,
+      "connection_label": "WIFI/BLE"
+     }
+    },
+    "runtime_safety": {
+     "allowed_for_manual_motion": true,
+     "blockers": [],
+     "blade_safe_for_motion": true,
+     "active_mowing_detected": false,
+     "active_route_detected": false,
+     "active_route_status": {
+      "route_present": false,
+      "progress_present": false,
+      "progress_is_active": false,
+      "blocks_motion": false,
+      "reason": "no_route",
+      "ha_state": "paused",
+      "work_mode_label": "MODE_READY"
+     },
+     "position_valid_for_motion": true,
+     "rtk_report_age_seconds": null,
+     "rtk_report_quiet_threshold_seconds": 1800.0,
+     "rtk_report_quiet": false,
+     "rtk_status_label": "Fix",
+     "rtk_degraded": false,
+     "rtk_degraded_override": false
+    },
+    "queue_settle": {
+     "live": true,
+     "reason": null,
+     "is_connected": true,
+     "is_usable": true,
+     "cooldown_active": false,
+     "cooldown_remaining_seconds": 0.0,
+     "last_send_age_seconds": 0.6,
+     "queue_depth": 0,
+     "queue_dispatch_paused": false,
+     "saga_active": false,
+     "stall_threshold_seconds": 15.0,
+     "queue_depth_limit": 0
+    },
+    "safety_gates": [
+     {
+      "name": "stop_primitive_available",
+      "passed": true,
+      "detail": "Coordinator must expose async_stop_manual_motion()."
+     },
+     {
+      "name": "ble_transport_required",
+      "passed": true,
+      "detail": "Real closed-loop motion requires the BLE transport for responsive telemetry; cloud/Wi-Fi lag is unsafe for guarded path execution. BLE must also report itself usable -- being selected for routing does not mean a command can be delivered."
+     },
+     {
+      "name": "ble_link_live",
+      "passed": true,
+      "detail": "Real motion requires a conservative BLE preflight -- a live client, an open dispatch gate, an empty command queue, and a recent outbound attempt. 'Usable' only means BLE is eligible for routing; it stays True while the command queue is gated and commands (including the mandatory stop that bounds a pulse) accumulate undelivered. The send path separately waits for confirmed queue start and GATT-write completion. See docs/pymammotion-ble-slot-leak-bug.md.",
+      "diagnostics": {
+       "live": true,
+       "reason": null,
+       "is_connected": true,
+       "is_usable": true,
+       "cooldown_active": false,
+       "cooldown_remaining_seconds": 0.0,
+       "last_send_age_seconds": 0.6,
+       "queue_depth": 0,
+       "queue_dispatch_paused": false,
+       "saga_active": false,
+       "stall_threshold_seconds": 15.0,
+       "queue_depth_limit": 0
+      }
+     },
+     {
+      "name": "operator_confirmed_blades_off",
+      "passed": true,
+      "detail": "Real pulse requires confirm_blades_off=true."
+     },
+     {
+      "name": "operator_confirmed_clear_area",
+      "passed": true,
+      "detail": "Real pulse requires confirm_clear_area=true."
+     },
+     {
+      "name": "mower_reports_blades_off",
+      "passed": true,
+      "detail": "Real pulse requires blade state off and cutter RPM zero/unknown."
+     },
+     {
+      "name": "mower_ready",
+      "passed": true,
+      "detail": "Real pulse requires the mower to be ready/paused, not mowing or charging."
+     },
+     {
+      "name": "not_docked_or_charging",
+      "passed": true,
+      "detail": "Real pulse requires the mower to be off the dock and not charging."
+     },
+     {
+      "name": "live_map_position_available",
+      "passed": true,
+      "detail": "Real pulse requires live map-local mower position."
+     },
+     {
+      "name": "position_area_inside",
+      "passed": true,
+      "detail": "Real pulse requires AREA_INSIDE, TURN_AREA_INSIDE, or CHANNEL_AREA_OVERLAP and a nonzero known zone hash."
+     },
+     {
+      "name": "map_position_nonzero",
+      "passed": true,
+      "detail": "Real pulse requires nonzero map-local x/y coordinates."
+     }
+    ],
+    "blockers": [],
+    "commands_sent": 3,
+    "turn_commands_sent": 0,
+    "linear_commands_sent": 2,
+    "motion_refresh_interval_ms": 200,
+    "motion_refresh_commands_sent": 6,
+    "app_speed_scale": {
+     "available": true,
+     "linear_speed": 400,
+     "angular_speed": 500,
+     "app_max_linear_speed": 850,
+     "app_max_angular_speed": 382,
+     "linear_fraction_of_app_max": 0.471,
+     "angular_fraction_of_app_max": 1.309,
+     "linear_above_app_max": false,
+     "angular_above_app_max": true
+    },
+    "calibration_commands_sent": 1,
+    "realignments": [],
+    "command_results": [
+     {
+      "index": 1,
+      "phase": "vio_calibration_drive",
+      "command": "send_movement",
+      "kwargs": {
+       "linear_speed": 400,
+       "angular_speed": 0
+      },
+      "sent_at_utc": "2026-08-14T20:27:06.003212+00:00",
+      "ok": true,
+      "error": null,
+      "stop_result": {
+       "attempted": true,
+       "ok": true,
+       "error": null,
+       "coordinator_method": "async_stop_manual_motion",
+       "use_wifi": false,
+       "transport_preference": "ble_preferred",
+       "ack": {
+        "movement_ok": true
+       },
+       "duration_ms": 75.016
+      },
+      "feedback_refresh": {
+       "method": "request_reports_count_5",
+       "settle_seconds": 0.0,
+       "ok": true,
+       "error": null,
+       "duration_ms": 0.445
+      }
+     },
+     {
+      "index": 1,
+      "phase": "linear_forward_to_target",
+      "attempted": true,
+      "ok": true,
+      "ack": null,
+      "error": null,
+      "duration_ms": 558.762,
+      "command": "send_movement",
+      "sent_at_utc": "2026-08-14T20:27:12.227569+00:00",
+      "prefer_ble": true,
+      "kwargs": {
+       "linear_speed": 400,
+       "angular_speed": 0
+      },
+      "selection": {
+       "command": "send_movement",
+       "linear_speed": 400,
+       "angular_speed": 0,
+       "distance_to_target": 0.6258864194085058,
+       "speed_tier": "fast",
+       "slow_linear_threshold": 0.15,
+       "reason": "target_remaining"
+      },
+      "final_approach": {
+       "applied": true,
+       "reason": "final_approach_bounded_by_refresh_count",
+       "distance_to_target": 0.6258864194085058,
+       "metres_per_pulse": 1.06,
+       "metres_per_pulse_source": "default",
+       "pulse_duration_ms": 1300.0,
+       "refresh_command_limit": 6,
+       "full_pulse_refresh_commands": 10,
+       "target_nonzero_writes": 7
+      },
+      "motion_refresh": {
+       "refresh_enabled": true,
+       "refresh_interval_ms": 200,
+       "refresh_commands_sent": 6,
+       "refresh_command_limit": 6,
+       "refresh_write_durations_ms": [
+        168.34,
+        80.666,
+        264.059,
+        225.544,
+        112.386,
+        91.772
+       ],
+       "max_refresh_commands": 6,
+       "elapsed_ms": 1294.161
+      },
+      "stop_result": {
+       "attempted": true,
+       "ok": true,
+       "error": null,
+       "coordinator_method": "async_stop_manual_motion",
+       "use_wifi": false,
+       "transport_preference": "ble_preferred",
+       "ack": {
+        "movement_ok": true
+       },
+       "duration_ms": 183.619
+      },
+      "post_command_feedback_refresh": {
+       "method": "request_reports_count_5",
+       "settle_seconds": 0.0,
+       "ok": true,
+       "error": null,
+       "duration_ms": 0.556
+      },
+      "position_settled": true,
+      "position_moved": true,
+      "position_settle_wait_seconds": 2.03,
+      "position_feed_stale": false,
+      "position_settle_polls": 2,
+      "position_source_comparison": {
+       "locations_xy": [
+        4.714,
+        -3.3575
+       ],
+       "locations_stale_zero": false,
+       "mowing_state_xy": [
+        0.0,
+        0.0
+       ],
+       "agreement_m": 5.7875,
+       "rtk_status": 0,
+       "pos_level": 0,
+       "pos_type": 0,
+       "zone_hash": 0
+      },
+      "post_settle_feedback": {
+       "source": "position_settle",
+       "additional_wait_seconds": 0.0,
+       "requested_sample_delays_skipped": [
+        0.0,
+        3.0
+       ]
+      },
+      "final_approach_observation": {
+       "measured_distance": 0.35676234386493183,
+       "nonzero_writes": 7,
+       "normalised_metres_per_eleven_writes": 0.5606
+      }
+     },
+     {
+      "index": 2,
+      "phase": "linear_forward_to_target",
+      "attempted": true,
+      "ok": false,
+      "ack": null,
+      "error": "RuntimeError: BLE link is not ready for motion: command_queue_backlogged",
+      "duration_ms": 0.064,
+      "command": "send_movement",
+      "sent_at_utc": "2026-08-14T20:27:16.297605+00:00",
+      "prefer_ble": true,
+      "kwargs": {
+       "linear_speed": 400,
+       "angular_speed": 0
+      },
+      "selection": {
+       "command": "send_movement",
+       "linear_speed": 400,
+       "angular_speed": 0,
+       "distance_to_target": 0.2697828756611511,
+       "speed_tier": "fast",
+       "slow_linear_threshold": 0.15,
+       "reason": "target_remaining"
+      },
+      "final_approach": {
+       "applied": true,
+       "reason": "final_approach_bounded_by_refresh_count",
+       "distance_to_target": 0.2697828756611511,
+       "metres_per_pulse": 1.06,
+       "metres_per_pulse_source": "default_conservative_floor",
+       "pulse_duration_ms": 1300.0,
+       "refresh_command_limit": 2,
+       "full_pulse_refresh_commands": 10,
+       "observed_metres_per_pulse": 0.5606,
+       "target_nonzero_writes": 3
+      }
+     }
+    ],
+    "samples": [
+     {
+      "label": "initial",
+      "telemetry": {
+       "online": true,
+       "work_mode": 11,
+       "work_mode_label": "MODE_READY",
+       "charge_state": 0,
+       "charge_state_label": "not_charging",
+       "position": {
+        "x": 5.0068,
+        "y": -3.0411,
+        "toward": -136.5265,
+        "source": "report_data.locations[0]",
+        "pos_level": 1,
+        "pos_level_label": "SINGLE",
+        "rtk_status": 4,
+        "rtk_status_label": "Fix",
+        "pos_type": 1,
+        "pos_type_label": "AREA_INSIDE",
+        "zone_hash": "1343645155037768237",
+        "map_bol_hash": "3192426378327374167",
+        "area_name": "Backyard Right",
+        "valid_for_motion": true
+       },
+       "position_candidates": [
+        {
+         "source": "mowing_state",
+         "x": 0.0,
+         "y": 0.0,
+         "toward": 0.0,
+         "pos_level": 0,
+         "pos_level_label": "FIX",
+         "rtk_status": 0,
+         "rtk_status_label": "None",
+         "pos_type": 0,
+         "pos_type_label": "AREA_OUT",
+         "zone_hash": 0,
+         "area_name": null,
+         "stale_zero_area_out": true,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.locations[0]",
+         "x": 5.0068,
+         "y": -3.0411,
+         "toward": -136.5265,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "location_metadata",
+         "x": null,
+         "y": null,
+         "toward": -136,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": "1343645155037768237",
+         "area_name": "Backyard Right",
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.rtk",
+         "x": null,
+         "y": null,
+         "toward": null,
+         "pos_level": 1,
+         "pos_level_label": "SINGLE",
+         "rtk_status": 4,
+         "rtk_status_label": "Fix",
+         "pos_type": null,
+         "pos_type_label": null,
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        }
+       ],
+       "blade": {
+        "reported_state": 0,
+        "reported_state_label": "OFF",
+        "knife_status": null,
+        "current_cutter_mode": 0,
+        "current_cutter_rpm": 0
+       },
+       "transport": {
+        "ble_rssi": -68,
+        "wifi_rssi": -51,
+        "wifi_connect_status": null,
+        "iot_connect_status": null,
+        "connection_label": "WIFI/BLE"
+       }
+      }
+     },
+     {
+      "label": "linear_1_position_settled",
+      "command_index": 1,
+      "delay_seconds": 2.03,
+      "source": "position_settle",
+      "telemetry": {
+       "online": true,
+       "work_mode": 11,
+       "work_mode_label": "MODE_READY",
+       "charge_state": 0,
+       "charge_state_label": "not_charging",
+       "position": {
+        "x": 4.714,
+        "y": -3.3575,
+        "toward": -136.5265,
+        "source": "report_data.locations[0]",
+        "pos_level": 1,
+        "pos_level_label": "SINGLE",
+        "rtk_status": 4,
+        "rtk_status_label": "Fix",
+        "pos_type": 1,
+        "pos_type_label": "AREA_INSIDE",
+        "zone_hash": "1343645155037768237",
+        "map_bol_hash": "3192426378327374167",
+        "area_name": "Backyard Right",
+        "valid_for_motion": true
+       },
+       "position_candidates": [
+        {
+         "source": "mowing_state",
+         "x": 0.0,
+         "y": 0.0,
+         "toward": 0.0,
+         "pos_level": 0,
+         "pos_level_label": "FIX",
+         "rtk_status": 0,
+         "rtk_status_label": "None",
+         "pos_type": 0,
+         "pos_type_label": "AREA_OUT",
+         "zone_hash": 0,
+         "area_name": null,
+         "stale_zero_area_out": true,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.locations[0]",
+         "x": 4.714,
+         "y": -3.3575,
+         "toward": -136.5265,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "location_metadata",
+         "x": null,
+         "y": null,
+         "toward": -136,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": "1343645155037768237",
+         "area_name": "Backyard Right",
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.rtk",
+         "x": null,
+         "y": null,
+         "toward": null,
+         "pos_level": 1,
+         "pos_level_label": "SINGLE",
+         "rtk_status": 4,
+         "rtk_status_label": "Fix",
+         "pos_type": null,
+         "pos_type_label": null,
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        }
+       ],
+       "blade": {
+        "reported_state": 0,
+        "reported_state_label": "OFF",
+        "knife_status": null,
+        "current_cutter_mode": 0,
+        "current_cutter_rpm": 0
+       },
+       "transport": {
+        "ble_rssi": -66,
+        "wifi_rssi": -51,
+        "wifi_connect_status": null,
+        "iot_connect_status": null,
+        "connection_label": "WIFI/BLE"
+       }
+      }
+     }
+    ],
+    "phases": [
+     {
+      "name": "turn_to_target_heading",
+      "turn_mode": "vio",
+      "passed": true,
+      "result": {
+       "service": "vio_turn_to_heading",
+       "mode": "real_vio_turn_to_heading",
+       "dry_run": false,
+       "real_execution_scope": "vio_turn_to_heading_only",
+       "path_execution_allowed": false,
+       "target_vision_heading": 222.1412329668437,
+       "heading_tolerance_degrees": 18.0,
+       "angular_speed": 500,
+       "pulse_duration_ms": 1500,
+       "slow_pulse_duration_ms": 700,
+       "slow_threshold_degrees": 15.0,
+       "refresh_wait_seconds": 2.0,
+       "effective_poll_interval_seconds": 2.0,
+       "fresh_heading_timeout_seconds": 8.0,
+       "max_commands": 4,
+       "min_progress_degrees": 2.0,
+       "max_no_progress_pulses": 2,
+       "max_displacement_m": 0.3,
+       "invert_direction": false,
+       "motion_refresh_interval_ms": 200,
+       "motion_refresh_commands_sent": 0,
+       "refresh_cadence_broken_pulses": 0,
+       "prefer_ble": true,
+       "confirm_blades_off": true,
+       "confirm_clear_area": true,
+       "active_transport": "ble",
+       "initial_vision_heading": -132.91902676953242,
+       "initial_vio_state": 2,
+       "initial_vio_feed": {
+        "live": true,
+        "tracked_features": 80,
+        "brightness_raw": 1,
+        "brightness_label": "Light"
+       },
+       "initial_heading_error_degrees": -4.94,
+       "safety_gates": [
+        {
+         "name": "stop_primitive_available",
+         "passed": true,
+         "detail": "Coordinator must expose async_stop_manual_motion()."
+        },
+        {
+         "name": "ble_transport_required",
+         "passed": true,
+         "detail": "Real closed-loop motion requires the BLE transport for responsive telemetry; cloud/Wi-Fi lag is unsafe for guarded path execution. BLE must also report itself usable -- being selected for routing does not mean a command can be delivered."
+        },
+        {
+         "name": "ble_link_live",
+         "passed": true,
+         "detail": "Real motion requires a conservative BLE preflight -- a live client, an open dispatch gate, an empty command queue, and a recent outbound attempt. 'Usable' only means BLE is eligible for routing; it stays True while the command queue is gated and commands (including the mandatory stop that bounds a pulse) accumulate undelivered. The send path separately waits for confirmed queue start and GATT-write completion. See docs/pymammotion-ble-slot-leak-bug.md.",
+         "diagnostics": {
+          "live": true,
+          "reason": null,
+          "is_connected": true,
+          "is_usable": true,
+          "cooldown_active": false,
+          "cooldown_remaining_seconds": 0.0,
+          "last_send_age_seconds": 0.0,
+          "queue_depth": 0,
+          "queue_dispatch_paused": false,
+          "saga_active": false,
+          "stall_threshold_seconds": 15.0,
+          "queue_depth_limit": 0
+         }
+        },
+        {
+         "name": "operator_confirmed_blades_off",
+         "passed": true,
+         "detail": "Real pulse requires confirm_blades_off=true."
+        },
+        {
+         "name": "operator_confirmed_clear_area",
+         "passed": true,
+         "detail": "Real pulse requires confirm_clear_area=true."
+        },
+        {
+         "name": "mower_reports_blades_off",
+         "passed": true,
+         "detail": "Real pulse requires blade state off and cutter RPM zero/unknown."
+        },
+        {
+         "name": "mower_ready",
+         "passed": true,
+         "detail": "Real pulse requires the mower to be ready/paused, not mowing or charging."
+        },
+        {
+         "name": "not_docked_or_charging",
+         "passed": true,
+         "detail": "Real pulse requires the mower to be off the dock and not charging."
+        },
+        {
+         "name": "live_map_position_available",
+         "passed": true,
+         "detail": "Real pulse requires live map-local mower position."
+        },
+        {
+         "name": "position_area_inside",
+         "passed": true,
+         "detail": "Real pulse requires AREA_INSIDE, TURN_AREA_INSIDE, or CHANNEL_AREA_OVERLAP and a nonzero known zone hash."
+        },
+        {
+         "name": "map_position_nonzero",
+         "passed": true,
+         "detail": "Real pulse requires nonzero map-local x/y coordinates."
+        }
+       ],
+       "runtime_safety": {
+        "allowed_for_manual_motion": true,
+        "blockers": [],
+        "blade_safe_for_motion": true,
+        "active_mowing_detected": false,
+        "active_route_detected": false,
+        "active_route_status": {
+         "route_present": false,
+         "progress_present": false,
+         "progress_is_active": false,
+         "blocks_motion": false,
+         "reason": "no_route",
+         "ha_state": "paused",
+         "work_mode_label": "MODE_READY"
+        },
+        "position_valid_for_motion": true,
+        "rtk_report_age_seconds": null,
+        "rtk_report_quiet_threshold_seconds": 1800.0,
+        "rtk_report_quiet": false,
+        "rtk_status_label": "Fix",
+        "rtk_degraded": false,
+        "rtk_degraded_override": false
+       },
+       "blockers": [],
+       "would_send": false,
+       "planned_command": {
+        "command": "send_movement",
+        "kwargs": {
+         "linear_speed": 0,
+         "angular_speed": 500
+        }
+       },
+       "commands_sent": 0,
+       "command_results": [],
+       "final_vision_heading": -132.91902676953242,
+       "final_heading_error_degrees": -4.94,
+       "final_vio_feed": {
+        "live": true,
+        "tracked_features": 80,
+        "brightness_raw": 1,
+        "brightness_label": "Light"
+       },
+       "final_displacement_m": 0.0,
+       "turn_degrees_per_second": 37.0,
+       "turn_feasibility": null,
+       "stop_reason": "target_heading_reached"
+      }
+     }
+    ],
+    "progress_diagnostics": [
+     {
+      "status": "path_progress",
+      "passed": true,
+      "action": "forward",
+      "path_progress_distance": 0.3564787205494169,
+      "expected_target_heading_degrees": 224.4756718351794,
+      "movement_vector_heading_degrees": 226.76047013377953,
+      "heading_progress": true,
+      "min_progress_distance": 0.0025,
+      "min_heading_change_degrees": 0.0,
+      "command_index": 1,
+      "measured_delta": {
+       "distance": 0.35676234386493183,
+       "dx": -0.24439999999999973,
+       "dy": -0.2599,
+       "heading_change_degrees": 0.0
+      }
+     }
+    ],
+    "completion_status": {
+     "complete": false,
+     "target_index": 1,
+     "distance_to_target": 0.2697828756611511,
+     "waypoint_distances": [
+      {
+       "index": 0,
+       "distance": 0.431092565465933,
+       "segment_projections": [
+        {
+         "segment_index": 0,
+         "target_index": 1,
+         "progress": 0.615353535353535,
+         "clamped_progress": 0.615353535353535,
+         "distance_to_segment": 0.01668772003600257
+        }
+       ]
+      },
+      {
+       "index": 1,
+       "distance": 0.2697828756611511,
+       "segment_projections": [
+        {
+         "segment_index": 0,
+         "target_index": 1,
+         "progress": 0.615353535353535,
+         "clamped_progress": 0.615353535353535,
+         "distance_to_segment": 0.01668772003600257
+        }
+       ]
+      }
+     ],
+     "reason": "target_remaining"
+    },
+    "stop_reason": "command_failed",
+    "linear_execution_mode": "loop_to_tolerance",
+    "effective_linear_ceiling": 14,
+    "linear_distance_ceiling": 1.2517728388170115
+   }
+  }
+ ],
+ "initial_telemetry": {
+  "online": true,
+  "work_mode": 11,
+  "work_mode_label": "MODE_READY",
+  "charge_state": 0,
+  "charge_state_label": "not_charging",
+  "position": {
+   "x": 5.0068,
+   "y": -3.0411,
+   "toward": -136.5265,
+   "source": "report_data.locations[0]",
+   "pos_level": 1,
+   "pos_level_label": "SINGLE",
+   "rtk_status": 4,
+   "rtk_status_label": "Fix",
+   "pos_type": 1,
+   "pos_type_label": "AREA_INSIDE",
+   "zone_hash": "1343645155037768237",
+   "map_bol_hash": "3192426378327374167",
+   "area_name": "Backyard Right",
+   "valid_for_motion": true
+  },
+  "position_candidates": [
+   {
+    "source": "mowing_state",
+    "x": 0.0,
+    "y": 0.0,
+    "toward": 0.0,
+    "pos_level": 0,
+    "pos_level_label": "FIX",
+    "rtk_status": 0,
+    "rtk_status_label": "None",
+    "pos_type": 0,
+    "pos_type_label": "AREA_OUT",
+    "zone_hash": 0,
+    "area_name": null,
+    "stale_zero_area_out": true,
+    "valid_for_motion": false
+   },
+   {
+    "source": "report_data.locations[0]",
+    "x": 5.0068,
+    "y": -3.0411,
+    "toward": -136.5265,
+    "pos_level": null,
+    "pos_level_label": null,
+    "rtk_status": null,
+    "rtk_status_label": null,
+    "pos_type": 1,
+    "pos_type_label": "AREA_INSIDE",
+    "zone_hash": null,
+    "area_name": null,
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   },
+   {
+    "source": "location_metadata",
+    "x": null,
+    "y": null,
+    "toward": -136,
+    "pos_level": null,
+    "pos_level_label": null,
+    "rtk_status": null,
+    "rtk_status_label": null,
+    "pos_type": 1,
+    "pos_type_label": "AREA_INSIDE",
+    "zone_hash": "1343645155037768237",
+    "area_name": "Backyard Right",
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   },
+   {
+    "source": "report_data.rtk",
+    "x": null,
+    "y": null,
+    "toward": null,
+    "pos_level": 1,
+    "pos_level_label": "SINGLE",
+    "rtk_status": 4,
+    "rtk_status_label": "Fix",
+    "pos_type": null,
+    "pos_type_label": null,
+    "zone_hash": null,
+    "area_name": null,
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   }
+  ],
+  "blade": {
+   "reported_state": 0,
+   "reported_state_label": "OFF",
+   "knife_status": null,
+   "current_cutter_mode": 0,
+   "current_cutter_rpm": 0
+  },
+  "transport": {
+   "ble_rssi": -68,
+   "wifi_rssi": -51,
+   "wifi_connect_status": null,
+   "iot_connect_status": null,
+   "connection_label": "WIFI/BLE"
+  }
+ },
+ "final_telemetry": {
+  "online": true,
+  "work_mode": 11,
+  "work_mode_label": "MODE_READY",
+  "charge_state": 0,
+  "charge_state_label": "not_charging",
+  "position": {
+   "x": 4.714,
+   "y": -3.3575,
+   "toward": -136.5265,
+   "source": "report_data.locations[0]",
+   "pos_level": 1,
+   "pos_level_label": "SINGLE",
+   "rtk_status": 4,
+   "rtk_status_label": "Fix",
+   "pos_type": 1,
+   "pos_type_label": "AREA_INSIDE",
+   "zone_hash": "1343645155037768237",
+   "map_bol_hash": "3192426378327374167",
+   "area_name": "Backyard Right",
+   "valid_for_motion": true
+  },
+  "position_candidates": [
+   {
+    "source": "mowing_state",
+    "x": 0.0,
+    "y": 0.0,
+    "toward": 0.0,
+    "pos_level": 0,
+    "pos_level_label": "FIX",
+    "rtk_status": 0,
+    "rtk_status_label": "None",
+    "pos_type": 0,
+    "pos_type_label": "AREA_OUT",
+    "zone_hash": 0,
+    "area_name": null,
+    "stale_zero_area_out": true,
+    "valid_for_motion": false
+   },
+   {
+    "source": "report_data.locations[0]",
+    "x": 4.714,
+    "y": -3.3575,
+    "toward": -136.5265,
+    "pos_level": null,
+    "pos_level_label": null,
+    "rtk_status": null,
+    "rtk_status_label": null,
+    "pos_type": 1,
+    "pos_type_label": "AREA_INSIDE",
+    "zone_hash": null,
+    "area_name": null,
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   },
+   {
+    "source": "location_metadata",
+    "x": null,
+    "y": null,
+    "toward": -136,
+    "pos_level": null,
+    "pos_level_label": null,
+    "rtk_status": null,
+    "rtk_status_label": null,
+    "pos_type": 1,
+    "pos_type_label": "AREA_INSIDE",
+    "zone_hash": "1343645155037768237",
+    "area_name": "Backyard Right",
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   },
+   {
+    "source": "report_data.rtk",
+    "x": null,
+    "y": null,
+    "toward": null,
+    "pos_level": 1,
+    "pos_level_label": "SINGLE",
+    "rtk_status": 4,
+    "rtk_status_label": "Fix",
+    "pos_type": null,
+    "pos_type_label": null,
+    "zone_hash": null,
+    "area_name": null,
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   }
+  ],
+  "blade": {
+   "reported_state": 0,
+   "reported_state_label": "OFF",
+   "knife_status": null,
+   "current_cutter_mode": 0,
+   "current_cutter_rpm": 0
+  },
+  "transport": {
+   "ble_rssi": -66,
+   "wifi_rssi": -51,
+   "wifi_connect_status": null,
+   "iot_connect_status": null,
+   "connection_label": "WIFI/BLE"
+  }
+ },
+ "runtime_safety": {
+  "allowed_for_manual_motion": true,
+  "blockers": [],
+  "blade_safe_for_motion": true,
+  "active_mowing_detected": false,
+  "active_route_detected": false,
+  "active_route_status": {
+   "route_present": false,
+   "progress_present": false,
+   "progress_is_active": false,
+   "blocks_motion": false,
+   "reason": "no_route",
+   "ha_state": "paused",
+   "work_mode_label": "MODE_READY"
+  },
+  "position_valid_for_motion": true,
+  "rtk_report_age_seconds": null,
+  "rtk_report_quiet_threshold_seconds": 1800.0,
+  "rtk_report_quiet": false,
+  "rtk_status_label": "Fix",
+  "rtk_degraded": false,
+  "rtk_degraded_override": false
+ },
+ "safety_gates": [
+  {
+   "name": "stop_primitive_available",
+   "passed": true,
+   "detail": "Coordinator must expose async_stop_manual_motion()."
+  },
+  {
+   "name": "ble_transport_required",
+   "passed": true,
+   "detail": "Real closed-loop motion requires the BLE transport for responsive telemetry; cloud/Wi-Fi lag is unsafe for guarded path execution. BLE must also report itself usable -- being selected for routing does not mean a command can be delivered."
+  },
+  {
+   "name": "ble_link_live",
+   "passed": true,
+   "detail": "Real motion requires a conservative BLE preflight -- a live client, an open dispatch gate, an empty command queue, and a recent outbound attempt. 'Usable' only means BLE is eligible for routing; it stays True while the command queue is gated and commands (including the mandatory stop that bounds a pulse) accumulate undelivered. The send path separately waits for confirmed queue start and GATT-write completion. See docs/pymammotion-ble-slot-leak-bug.md.",
+   "diagnostics": {
+    "live": true,
+    "reason": null,
+    "is_connected": true,
+    "is_usable": true,
+    "cooldown_active": false,
+    "cooldown_remaining_seconds": 0.0,
+    "last_send_age_seconds": 0.6,
+    "queue_depth": 0,
+    "queue_dispatch_paused": false,
+    "saga_active": false,
+    "stall_threshold_seconds": 15.0,
+    "queue_depth_limit": 0
+   }
+  },
+  {
+   "name": "operator_confirmed_blades_off",
+   "passed": true,
+   "detail": "Real pulse requires confirm_blades_off=true."
+  },
+  {
+   "name": "operator_confirmed_clear_area",
+   "passed": true,
+   "detail": "Real pulse requires confirm_clear_area=true."
+  },
+  {
+   "name": "mower_reports_blades_off",
+   "passed": true,
+   "detail": "Real pulse requires blade state off and cutter RPM zero/unknown."
+  },
+  {
+   "name": "mower_ready",
+   "passed": true,
+   "detail": "Real pulse requires the mower to be ready/paused, not mowing or charging."
+  },
+  {
+   "name": "not_docked_or_charging",
+   "passed": true,
+   "detail": "Real pulse requires the mower to be off the dock and not charging."
+  },
+  {
+   "name": "live_map_position_available",
+   "passed": true,
+   "detail": "Real pulse requires live map-local mower position."
+  },
+  {
+   "name": "position_area_inside",
+   "passed": true,
+   "detail": "Real pulse requires AREA_INSIDE, TURN_AREA_INSIDE, or CHANNEL_AREA_OVERLAP and a nonzero known zone hash."
+  },
+  {
+   "name": "map_position_nonzero",
+   "passed": true,
+   "detail": "Real pulse requires nonzero map-local x/y coordinates."
+  }
+ ],
+ "blockers": [],
+ "stop_reason": "segment_failed",
+ "failed_segment_index": 1,
+ "junction_turn_feasibility": []
+}

--- a/docs/evidence-beta32-4segment-20260814T204300Z.json
+++ b/docs/evidence-beta32-4segment-20260814T204300Z.json
@@ -1,0 +1,2153 @@
+{
+ "valid": true,
+ "errors": [],
+ "warnings": [],
+ "coordinate_system": "mower_map_xy",
+ "blade_mode": "off",
+ "speed": 0.2,
+ "area_hash": null,
+ "point_count": 2,
+ "distance": 0.7000357133746816,
+ "points": [
+  {
+   "x": 4.7113,
+   "y": -3.362
+  },
+  {
+   "x": 4.2163,
+   "y": -3.857
+  }
+ ],
+ "geojson": {
+  "type": "FeatureCollection",
+  "features": [
+   {
+    "type": "Feature",
+    "properties": {
+     "type_name": "custom_path_start",
+     "Name": "Start",
+     "marker": "start"
+    },
+    "geometry": {
+     "type": "Point",
+     "coordinates": [
+      4.7113,
+      -3.362
+     ]
+    }
+   },
+   {
+    "type": "Feature",
+    "properties": {
+     "type_name": "custom_path",
+     "Name": "Custom path",
+     "valid": true,
+     "distance": 0.7000357133746816,
+     "color": "#22c55e",
+     "weight": 3
+    },
+    "geometry": {
+     "type": "LineString",
+     "coordinates": [
+      [
+       4.7113,
+       -3.362
+      ],
+      [
+       4.2163,
+       -3.857
+      ]
+     ]
+    }
+   },
+   {
+    "type": "Feature",
+    "properties": {
+     "type_name": "custom_path_end",
+     "Name": "End",
+     "marker": "end"
+    },
+    "geometry": {
+     "type": "Point",
+     "coordinates": [
+      4.2163,
+      -3.857
+     ]
+    }
+   }
+  ]
+ },
+ "path": {
+  "coordinate_system": "mower_map_xy",
+  "points": [
+   {
+    "x": 4.7113,
+    "y": -3.362
+   },
+   {
+    "x": 4.2163,
+    "y": -3.857
+   }
+  ],
+  "distance": 0.7000357133746816
+ },
+ "service": "raw_pymammotion_execute_multi_segment",
+ "mode": "real_raw_multi_segment",
+ "dry_run": false,
+ "would_send": true,
+ "real_execution_scope": "guarded_multi_segment_vector_chain",
+ "full_path_execution_allowed": false,
+ "ready_for_multi_point": false,
+ "ready_for_multi_segment": true,
+ "initial_vio_feed": {
+  "live": true,
+  "tracked_features": 80,
+  "brightness_raw": 1,
+  "brightness_label": "Light"
+ },
+ "prefer_ble": true,
+ "transport_preference": "ble_preferred",
+ "ble_auto_recover": false,
+ "ble_recovery": null,
+ "max_real_segments": 1,
+ "max_turn_commands": 4,
+ "max_linear_commands": 3,
+ "linear_speed_fast": 400,
+ "linear_speed_slow": 200,
+ "slow_linear_threshold": 0.15,
+ "heading_tolerance_degrees": 18.0,
+ "angular_speed_fast": 180,
+ "angular_speed_slow": 180,
+ "slow_turn_threshold_degrees": 8.0,
+ "waypoint_tolerance": 0.15,
+ "min_progress_distance": 0.0025,
+ "min_heading_change_degrees": 0.5,
+ "max_turn_translation_distance": 0.3,
+ "calibrated_forward_heading_offset_degrees": 102.4,
+ "turn_mode": "vio",
+ "vio_heading_offset_degrees": null,
+ "turn_pulse_duration_ms": 1500.0,
+ "linear_pulse_duration_ms": 1300.0,
+ "final_approach_metres_per_pulse": 1.06,
+ "turn_degrees_per_second": 37.0,
+ "vio_turn_max_commands": 4,
+ "vio_angular_speed": 500,
+ "max_linear_pulse_ceiling": 14,
+ "max_no_progress_pulses": 3,
+ "motion_refresh_interval_ms": 200,
+ "sample_delays": [
+  0.0,
+  3.0
+ ],
+ "confirm_blades_off": true,
+ "confirm_clear_area": true,
+ "total_segments": 1,
+ "segments_planned": 1,
+ "segments_executed": 1,
+ "real_segments_executed": 1,
+ "segments": [
+  {
+   "index": 1,
+   "points": [
+    {
+     "x": 4.7113,
+     "y": -3.362
+    },
+    {
+     "x": 4.2163,
+     "y": -3.857
+    }
+   ],
+   "real_segment": true,
+   "passed": true,
+   "result": {
+    "valid": true,
+    "errors": [],
+    "warnings": [],
+    "coordinate_system": "mower_map_xy",
+    "blade_mode": "off",
+    "speed": 0.2,
+    "area_hash": null,
+    "point_count": 2,
+    "distance": 0.7000357133746816,
+    "points": [
+     {
+      "x": 4.7113,
+      "y": -3.362
+     },
+     {
+      "x": 4.2163,
+      "y": -3.857
+     }
+    ],
+    "geojson": {
+     "type": "FeatureCollection",
+     "features": [
+      {
+       "type": "Feature",
+       "properties": {
+        "type_name": "custom_path_start",
+        "Name": "Start",
+        "marker": "start"
+       },
+       "geometry": {
+        "type": "Point",
+        "coordinates": [
+         4.7113,
+         -3.362
+        ]
+       }
+      },
+      {
+       "type": "Feature",
+       "properties": {
+        "type_name": "custom_path",
+        "Name": "Custom path",
+        "valid": true,
+        "distance": 0.7000357133746816,
+        "color": "#22c55e",
+        "weight": 3
+       },
+       "geometry": {
+        "type": "LineString",
+        "coordinates": [
+         [
+          4.7113,
+          -3.362
+         ],
+         [
+          4.2163,
+          -3.857
+         ]
+        ]
+       }
+      },
+      {
+       "type": "Feature",
+       "properties": {
+        "type_name": "custom_path_end",
+        "Name": "End",
+        "marker": "end"
+       },
+       "geometry": {
+        "type": "Point",
+        "coordinates": [
+         4.2163,
+         -3.857
+        ]
+       }
+      }
+     ]
+    },
+    "path": {
+     "coordinate_system": "mower_map_xy",
+     "points": [
+      {
+       "x": 4.7113,
+       "y": -3.362
+      },
+      {
+       "x": 4.2163,
+       "y": -3.857
+      }
+     ],
+     "distance": 0.7000357133746816
+    },
+    "service": "raw_pymammotion_execute_vector_segment",
+    "mode": "real_raw_vector_segment",
+    "dry_run": false,
+    "would_send": true,
+    "real_execution_scope": "one_segment_turn_then_forward_only",
+    "full_path_execution_allowed": false,
+    "ready_for_multi_point": false,
+    "prefer_ble": true,
+    "transport_preference": "ble_preferred",
+    "ble_auto_recover": false,
+    "ble_recovery": null,
+    "linear_speed_fast": 400,
+    "linear_speed_slow": 200,
+    "slow_linear_threshold": 0.15,
+    "max_turn_commands": 4,
+    "max_linear_commands": 3,
+    "heading_tolerance_degrees": 18.0,
+    "angular_speed_fast": 180,
+    "angular_speed_slow": 180,
+    "slow_turn_threshold_degrees": 8.0,
+    "waypoint_tolerance": 0.15,
+    "min_progress_distance": 0.0025,
+    "min_heading_change_degrees": 0.5,
+    "max_turn_translation_distance": 0.3,
+    "calibrated_forward_heading_offset_degrees": 102.4,
+    "max_linear_pulse_ceiling": 14,
+    "max_no_progress_pulses": 3,
+    "final_approach_metres_per_pulse": 1.06,
+    "turn_degrees_per_second": 37.0,
+    "turn_pulse_duration_ms": 1500.0,
+    "linear_pulse_duration_ms": 1300.0,
+    "vio_turn_max_commands": 4,
+    "vio_angular_speed": 500,
+    "vio_heading_offset_degrees": null,
+    "sample_delays": [
+     0.0,
+     3.0
+    ],
+    "confirm_blades_off": true,
+    "confirm_clear_area": true,
+    "advisory_start": {
+     "x": 4.7113,
+     "y": -3.362
+    },
+    "true_start": {
+     "x": 4.7113,
+     "y": -3.362
+    },
+    "target": {
+     "x": 4.2163,
+     "y": -3.857
+    },
+    "target_map_heading_degrees": 225.07109455738114,
+    "target_reported_heading_degrees": 122.60000000000005,
+    "target_heading_degrees": 122.60000000000005,
+    "heading_calibration": {
+     "formula": "target_reported_heading = target_map_heading - calibrated_forward_heading_offset",
+     "target_map_heading_degrees": 225.00000000000006,
+     "calibrated_forward_heading_offset_degrees": 102.4,
+     "target_reported_heading_degrees": 122.60000000000005
+    },
+    "initial_linear_command_selection": {
+     "command": "send_movement",
+     "linear_speed": 400,
+     "angular_speed": 0,
+     "distance_to_target": 0.7000357133746816,
+     "speed_tier": "fast",
+     "slow_linear_threshold": 0.15,
+     "reason": "target_remaining"
+    },
+    "turn_mode": "vio",
+    "vio": {
+     "initial_vio_state": 2,
+     "initial_vio_feed": {
+      "live": true,
+      "tracked_features": 80,
+      "brightness_raw": 1,
+      "brightness_label": "Light"
+     },
+     "initial_vision_heading": -132.59540783014666,
+     "provided_offset_degrees": null,
+     "offset_degrees": 357.2796719963685,
+     "offset_source": "linear_refresh",
+     "target_vision_heading": 227.90230127035696,
+     "calibration": {
+      "passed": true,
+      "reason": "calibrated",
+      "offset_degrees": 357.1687932870242,
+      "map_motion_heading_degrees": 224.391,
+      "vision_heading": -132.77771101281903,
+      "vio_state": 2,
+      "vio_feed": {
+       "live": true,
+       "tracked_features": 80,
+       "brightness_raw": 1,
+       "brightness_label": "Light"
+      },
+      "distance_m": 0.07318968506558794,
+      "pulses_sent": 1,
+      "command_results": [
+       {
+        "index": 1,
+        "phase": "vio_calibration_drive",
+        "command": "send_movement",
+        "kwargs": {
+         "linear_speed": 400,
+         "angular_speed": 0
+        },
+        "sent_at_utc": "2026-08-14T20:43:00.908965+00:00",
+        "ok": true,
+        "error": null,
+        "stop_result": {
+         "attempted": true,
+         "ok": true,
+         "error": null,
+         "coordinator_method": "async_stop_manual_motion",
+         "use_wifi": false,
+         "transport_preference": "ble_preferred",
+         "ack": {
+          "movement_ok": true
+         },
+         "duration_ms": 246.162
+        },
+        "feedback_refresh": {
+         "method": "request_reports_count_5",
+         "settle_seconds": 0.0,
+         "ok": true,
+         "error": null,
+         "duration_ms": 0.576
+        }
+       }
+      ]
+     },
+     "formula": "target_vision_heading = target_map_heading - (map_motion_heading - vision_heading)"
+    },
+    "initial_telemetry": {
+     "online": true,
+     "work_mode": 11,
+     "work_mode_label": "MODE_READY",
+     "charge_state": 0,
+     "charge_state_label": "not_charging",
+     "position": {
+      "x": 4.7113,
+      "y": -3.362,
+      "toward": -136.5265,
+      "source": "report_data.locations[0]",
+      "pos_level": 1,
+      "pos_level_label": "SINGLE",
+      "rtk_status": 4,
+      "rtk_status_label": "Fix",
+      "pos_type": 1,
+      "pos_type_label": "AREA_INSIDE",
+      "zone_hash": "1343645155037768237",
+      "map_bol_hash": "3192426378327374167",
+      "area_name": "Backyard Right",
+      "valid_for_motion": true
+     },
+     "position_candidates": [
+      {
+       "source": "mowing_state",
+       "x": 0.0,
+       "y": 0.0,
+       "toward": 0.0,
+       "pos_level": 0,
+       "pos_level_label": "FIX",
+       "rtk_status": 0,
+       "rtk_status_label": "None",
+       "pos_type": 0,
+       "pos_type_label": "AREA_OUT",
+       "zone_hash": 0,
+       "area_name": null,
+       "stale_zero_area_out": true,
+       "valid_for_motion": false
+      },
+      {
+       "source": "report_data.locations[0]",
+       "x": 4.7113,
+       "y": -3.362,
+       "toward": -136.5265,
+       "pos_level": null,
+       "pos_level_label": null,
+       "rtk_status": null,
+       "rtk_status_label": null,
+       "pos_type": 1,
+       "pos_type_label": "AREA_INSIDE",
+       "zone_hash": null,
+       "area_name": null,
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      },
+      {
+       "source": "location_metadata",
+       "x": null,
+       "y": null,
+       "toward": -136,
+       "pos_level": null,
+       "pos_level_label": null,
+       "rtk_status": null,
+       "rtk_status_label": null,
+       "pos_type": 1,
+       "pos_type_label": "AREA_INSIDE",
+       "zone_hash": "1343645155037768237",
+       "area_name": "Backyard Right",
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      },
+      {
+       "source": "report_data.rtk",
+       "x": null,
+       "y": null,
+       "toward": null,
+       "pos_level": 1,
+       "pos_level_label": "SINGLE",
+       "rtk_status": 4,
+       "rtk_status_label": "Fix",
+       "pos_type": null,
+       "pos_type_label": null,
+       "zone_hash": null,
+       "area_name": null,
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      }
+     ],
+     "blade": {
+      "reported_state": 0,
+      "reported_state_label": "OFF",
+      "knife_status": null,
+      "current_cutter_mode": 0,
+      "current_cutter_rpm": 0
+     },
+     "transport": {
+      "ble_rssi": -64,
+      "wifi_rssi": -50,
+      "wifi_connect_status": null,
+      "iot_connect_status": null,
+      "connection_label": "WIFI/BLE"
+     }
+    },
+    "final_telemetry": {
+     "online": true,
+     "work_mode": 11,
+     "work_mode_label": "MODE_READY",
+     "charge_state": 0,
+     "charge_state_label": "not_charging",
+     "position": {
+      "x": 4.2954,
+      "y": -3.8079,
+      "toward": -137.6495,
+      "source": "report_data.locations[0]",
+      "pos_level": 1,
+      "pos_level_label": "SINGLE",
+      "rtk_status": 4,
+      "rtk_status_label": "Fix",
+      "pos_type": 1,
+      "pos_type_label": "AREA_INSIDE",
+      "zone_hash": "1343645155037768237",
+      "map_bol_hash": "3192426378327374167",
+      "area_name": "Backyard Right",
+      "valid_for_motion": true
+     },
+     "position_candidates": [
+      {
+       "source": "mowing_state",
+       "x": 0.0,
+       "y": 0.0,
+       "toward": 0.0,
+       "pos_level": 0,
+       "pos_level_label": "FIX",
+       "rtk_status": 0,
+       "rtk_status_label": "None",
+       "pos_type": 0,
+       "pos_type_label": "AREA_OUT",
+       "zone_hash": 0,
+       "area_name": null,
+       "stale_zero_area_out": true,
+       "valid_for_motion": false
+      },
+      {
+       "source": "report_data.locations[0]",
+       "x": 4.2954,
+       "y": -3.8079,
+       "toward": -137.6495,
+       "pos_level": null,
+       "pos_level_label": null,
+       "rtk_status": null,
+       "rtk_status_label": null,
+       "pos_type": 1,
+       "pos_type_label": "AREA_INSIDE",
+       "zone_hash": null,
+       "area_name": null,
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      },
+      {
+       "source": "location_metadata",
+       "x": null,
+       "y": null,
+       "toward": -137,
+       "pos_level": null,
+       "pos_level_label": null,
+       "rtk_status": null,
+       "rtk_status_label": null,
+       "pos_type": 1,
+       "pos_type_label": "AREA_INSIDE",
+       "zone_hash": "1343645155037768237",
+       "area_name": "Backyard Right",
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      },
+      {
+       "source": "report_data.rtk",
+       "x": null,
+       "y": null,
+       "toward": null,
+       "pos_level": 1,
+       "pos_level_label": "SINGLE",
+       "rtk_status": 4,
+       "rtk_status_label": "Fix",
+       "pos_type": null,
+       "pos_type_label": null,
+       "zone_hash": null,
+       "area_name": null,
+       "stale_zero_area_out": false,
+       "valid_for_motion": false
+      }
+     ],
+     "blade": {
+      "reported_state": 0,
+      "reported_state_label": "OFF",
+      "knife_status": null,
+      "current_cutter_mode": 0,
+      "current_cutter_rpm": 0
+     },
+     "transport": {
+      "ble_rssi": -64,
+      "wifi_rssi": -48,
+      "wifi_connect_status": null,
+      "iot_connect_status": null,
+      "connection_label": "WIFI/BLE"
+     }
+    },
+    "runtime_safety": {
+     "allowed_for_manual_motion": true,
+     "blockers": [],
+     "blade_safe_for_motion": true,
+     "active_mowing_detected": false,
+     "active_route_detected": false,
+     "active_route_status": {
+      "route_present": false,
+      "progress_present": false,
+      "progress_is_active": false,
+      "blocks_motion": false,
+      "reason": "no_route",
+      "ha_state": "paused",
+      "work_mode_label": "MODE_READY"
+     },
+     "position_valid_for_motion": true,
+     "rtk_report_age_seconds": null,
+     "rtk_report_quiet_threshold_seconds": 1800.0,
+     "rtk_report_quiet": false,
+     "rtk_status_label": "Fix",
+     "rtk_degraded": false,
+     "rtk_degraded_override": false
+    },
+    "queue_settle": {
+     "live": true,
+     "reason": null,
+     "is_connected": true,
+     "is_usable": true,
+     "cooldown_active": false,
+     "cooldown_remaining_seconds": 0.0,
+     "last_send_age_seconds": 0.6,
+     "queue_depth": 0,
+     "queue_dispatch_paused": false,
+     "saga_active": false,
+     "stall_threshold_seconds": 15.0,
+     "queue_depth_limit": 0
+    },
+    "safety_gates": [
+     {
+      "name": "stop_primitive_available",
+      "passed": true,
+      "detail": "Coordinator must expose async_stop_manual_motion()."
+     },
+     {
+      "name": "ble_transport_required",
+      "passed": true,
+      "detail": "Real closed-loop motion requires the BLE transport for responsive telemetry; cloud/Wi-Fi lag is unsafe for guarded path execution. BLE must also report itself usable -- being selected for routing does not mean a command can be delivered."
+     },
+     {
+      "name": "ble_link_live",
+      "passed": true,
+      "detail": "Real motion requires a conservative BLE preflight -- a live client, an open dispatch gate, an empty command queue, and a recent outbound attempt. 'Usable' only means BLE is eligible for routing; it stays True while the command queue is gated and commands (including the mandatory stop that bounds a pulse) accumulate undelivered. The send path separately waits for confirmed queue start and GATT-write completion. See docs/pymammotion-ble-slot-leak-bug.md.",
+      "diagnostics": {
+       "live": true,
+       "reason": null,
+       "is_connected": true,
+       "is_usable": true,
+       "cooldown_active": false,
+       "cooldown_remaining_seconds": 0.0,
+       "last_send_age_seconds": 0.6,
+       "queue_depth": 0,
+       "queue_dispatch_paused": false,
+       "saga_active": false,
+       "stall_threshold_seconds": 15.0,
+       "queue_depth_limit": 0
+      }
+     },
+     {
+      "name": "operator_confirmed_blades_off",
+      "passed": true,
+      "detail": "Real pulse requires confirm_blades_off=true."
+     },
+     {
+      "name": "operator_confirmed_clear_area",
+      "passed": true,
+      "detail": "Real pulse requires confirm_clear_area=true."
+     },
+     {
+      "name": "mower_reports_blades_off",
+      "passed": true,
+      "detail": "Real pulse requires blade state off and cutter RPM zero/unknown."
+     },
+     {
+      "name": "mower_ready",
+      "passed": true,
+      "detail": "Real pulse requires the mower to be ready/paused, not mowing or charging."
+     },
+     {
+      "name": "not_docked_or_charging",
+      "passed": true,
+      "detail": "Real pulse requires the mower to be off the dock and not charging."
+     },
+     {
+      "name": "live_map_position_available",
+      "passed": true,
+      "detail": "Real pulse requires live map-local mower position."
+     },
+     {
+      "name": "position_area_inside",
+      "passed": true,
+      "detail": "Real pulse requires AREA_INSIDE, TURN_AREA_INSIDE, or CHANNEL_AREA_OVERLAP and a nonzero known zone hash."
+     },
+     {
+      "name": "map_position_nonzero",
+      "passed": true,
+      "detail": "Real pulse requires nonzero map-local x/y coordinates."
+     }
+    ],
+    "blockers": [],
+    "commands_sent": 4,
+    "turn_commands_sent": 0,
+    "linear_commands_sent": 3,
+    "motion_refresh_interval_ms": 200,
+    "motion_refresh_commands_sent": 9,
+    "app_speed_scale": {
+     "available": true,
+     "linear_speed": 400,
+     "angular_speed": 500,
+     "app_max_linear_speed": 850,
+     "app_max_angular_speed": 382,
+     "linear_fraction_of_app_max": 0.471,
+     "angular_fraction_of_app_max": 1.309,
+     "linear_above_app_max": false,
+     "angular_above_app_max": true
+    },
+    "calibration_commands_sent": 1,
+    "realignments": [],
+    "command_results": [
+     {
+      "index": 1,
+      "phase": "vio_calibration_drive",
+      "command": "send_movement",
+      "kwargs": {
+       "linear_speed": 400,
+       "angular_speed": 0
+      },
+      "sent_at_utc": "2026-08-14T20:43:00.908965+00:00",
+      "ok": true,
+      "error": null,
+      "stop_result": {
+       "attempted": true,
+       "ok": true,
+       "error": null,
+       "coordinator_method": "async_stop_manual_motion",
+       "use_wifi": false,
+       "transport_preference": "ble_preferred",
+       "ack": {
+        "movement_ok": true
+       },
+       "duration_ms": 246.162
+      },
+      "feedback_refresh": {
+       "method": "request_reports_count_5",
+       "settle_seconds": 0.0,
+       "ok": true,
+       "error": null,
+       "duration_ms": 0.576
+      }
+     },
+     {
+      "index": 1,
+      "phase": "linear_forward_to_target",
+      "attempted": true,
+      "ok": true,
+      "ack": null,
+      "error": null,
+      "duration_ms": 86.696,
+      "command": "send_movement",
+      "sent_at_utc": "2026-08-14T20:43:07.340070+00:00",
+      "prefer_ble": true,
+      "kwargs": {
+       "linear_speed": 400,
+       "angular_speed": 0
+      },
+      "selection": {
+       "command": "send_movement",
+       "linear_speed": 400,
+       "angular_speed": 0,
+       "distance_to_target": 0.6268506440931523,
+       "speed_tier": "fast",
+       "slow_linear_threshold": 0.15,
+       "reason": "target_remaining"
+      },
+      "final_approach": {
+       "applied": true,
+       "reason": "final_approach_bounded_by_refresh_count",
+       "distance_to_target": 0.6268506440931523,
+       "metres_per_pulse": 1.06,
+       "metres_per_pulse_source": "default",
+       "pulse_duration_ms": 1300.0,
+       "refresh_command_limit": 6,
+       "full_pulse_refresh_commands": 10,
+       "target_nonzero_writes": 7
+      },
+      "motion_refresh": {
+       "refresh_enabled": true,
+       "refresh_interval_ms": 200,
+       "refresh_commands_sent": 6,
+       "refresh_command_limit": 6,
+       "refresh_write_durations_ms": [
+        205.377,
+        128.672,
+        119.285,
+        129.808,
+        122.746,
+        139.283
+       ],
+       "max_refresh_commands": 6,
+       "elapsed_ms": 1340.339
+      },
+      "stop_result": {
+       "attempted": true,
+       "ok": true,
+       "error": null,
+       "coordinator_method": "async_stop_manual_motion",
+       "use_wifi": false,
+       "transport_preference": "ble_preferred",
+       "ack": {
+        "movement_ok": true
+       },
+       "duration_ms": 113.378
+      },
+      "post_command_feedback_refresh": {
+       "method": "request_reports_count_5",
+       "settle_seconds": 0.0,
+       "ok": true,
+       "error": null,
+       "duration_ms": 0.465
+      },
+      "position_settled": true,
+      "position_moved": true,
+      "position_settle_wait_seconds": 3.01,
+      "position_feed_stale": false,
+      "position_settle_polls": 3,
+      "post_feedback_queue_settle": {
+       "live": true,
+       "reason": null,
+       "is_connected": true,
+       "is_usable": true,
+       "cooldown_active": false,
+       "cooldown_remaining_seconds": 0.0,
+       "last_send_age_seconds": 0.1,
+       "queue_depth": 0,
+       "queue_dispatch_paused": false,
+       "saga_active": false,
+       "stall_threshold_seconds": 15.0,
+       "queue_depth_limit": 0,
+       "duration_ms": 101.225
+      },
+      "position_source_comparison": {
+       "locations_xy": [
+        4.4151,
+        -3.6761
+       ],
+       "locations_stale_zero": false,
+       "mowing_state_xy": [
+        0.0,
+        0.0
+       ],
+       "agreement_m": 5.7452,
+       "rtk_status": 0,
+       "pos_level": 0,
+       "pos_type": 0,
+       "zone_hash": 0
+      },
+      "post_settle_feedback": {
+       "source": "position_settle",
+       "additional_wait_seconds": 0.0,
+       "requested_sample_delays_skipped": [
+        0.0,
+        3.0
+       ]
+      },
+      "final_approach_observation": {
+       "measured_distance": 0.3586134687933515,
+       "nonzero_writes": 7,
+       "normalised_metres_per_eleven_writes": 0.5635
+      }
+     },
+     {
+      "index": 2,
+      "phase": "linear_forward_to_target",
+      "attempted": true,
+      "ok": true,
+      "ack": null,
+      "error": null,
+      "duration_ms": 230.933,
+      "command": "send_movement",
+      "sent_at_utc": "2026-08-14T20:43:11.988911+00:00",
+      "prefer_ble": true,
+      "kwargs": {
+       "linear_speed": 400,
+       "angular_speed": 0
+      },
+      "selection": {
+       "command": "send_movement",
+       "linear_speed": 400,
+       "angular_speed": 0,
+       "distance_to_target": 0.26878662541131,
+       "speed_tier": "fast",
+       "slow_linear_threshold": 0.15,
+       "reason": "target_remaining"
+      },
+      "final_approach": {
+       "applied": true,
+       "reason": "final_approach_bounded_by_refresh_count",
+       "distance_to_target": 0.26878662541131,
+       "metres_per_pulse": 1.06,
+       "metres_per_pulse_source": "default_conservative_floor",
+       "pulse_duration_ms": 1300.0,
+       "refresh_command_limit": 2,
+       "full_pulse_refresh_commands": 10,
+       "observed_metres_per_pulse": 0.5635,
+       "target_nonzero_writes": 3
+      },
+      "motion_refresh": {
+       "refresh_enabled": true,
+       "refresh_interval_ms": 200,
+       "refresh_commands_sent": 2,
+       "refresh_command_limit": 2,
+       "refresh_write_durations_ms": [
+        141.429,
+        127.677
+       ],
+       "max_refresh_commands": 2,
+       "elapsed_ms": 528.039
+      },
+      "stop_result": {
+       "attempted": true,
+       "ok": true,
+       "error": null,
+       "coordinator_method": "async_stop_manual_motion",
+       "use_wifi": false,
+       "transport_preference": "ble_preferred",
+       "ack": {
+        "movement_ok": true
+       },
+       "duration_ms": 101.984
+      },
+      "post_command_feedback_refresh": {
+       "method": "request_reports_count_5",
+       "settle_seconds": 0.0,
+       "ok": true,
+       "error": null,
+       "duration_ms": 0.424
+      },
+      "position_settled": true,
+      "position_moved": true,
+      "position_settle_wait_seconds": 3.01,
+      "position_feed_stale": false,
+      "position_settle_polls": 3,
+      "post_feedback_queue_settle": {
+       "live": true,
+       "reason": null,
+       "is_connected": true,
+       "is_usable": true,
+       "cooldown_active": false,
+       "cooldown_remaining_seconds": 0.0,
+       "last_send_age_seconds": 0.1,
+       "queue_depth": 0,
+       "queue_dispatch_paused": false,
+       "saga_active": false,
+       "stall_threshold_seconds": 15.0,
+       "queue_depth_limit": 0,
+       "duration_ms": 100.702
+      },
+      "position_source_comparison": {
+       "locations_xy": [
+        4.3414,
+        -3.7502
+       ],
+       "locations_stale_zero": false,
+       "mowing_state_xy": [
+        0.0,
+        0.0
+       ],
+       "agreement_m": 5.7369,
+       "rtk_status": 0,
+       "pos_level": 0,
+       "pos_type": 0,
+       "zone_hash": 0
+      },
+      "post_settle_feedback": {
+       "source": "position_settle",
+       "additional_wait_seconds": 0.0,
+       "requested_sample_delays_skipped": [
+        0.0,
+        3.0
+       ]
+      },
+      "final_approach_observation": {
+       "measured_distance": 0.1045107649957647,
+       "nonzero_writes": 3,
+       "normalised_metres_per_eleven_writes": 0.3832
+      }
+     },
+     {
+      "index": 3,
+      "phase": "linear_forward_to_target",
+      "attempted": true,
+      "ok": true,
+      "ack": null,
+      "error": null,
+      "duration_ms": 356.674,
+      "command": "send_movement",
+      "sent_at_utc": "2026-08-14T20:43:15.958527+00:00",
+      "prefer_ble": true,
+      "kwargs": {
+       "linear_speed": 400,
+       "angular_speed": 0
+      },
+      "selection": {
+       "command": "send_movement",
+       "linear_speed": 400,
+       "angular_speed": 0,
+       "distance_to_target": 0.1644878414959598,
+       "speed_tier": "fast",
+       "slow_linear_threshold": 0.15,
+       "reason": "target_remaining"
+      },
+      "final_approach": {
+       "applied": true,
+       "reason": "final_approach_bounded_by_refresh_count",
+       "distance_to_target": 0.1644878414959598,
+       "metres_per_pulse": 1.06,
+       "metres_per_pulse_source": "default_conservative_floor",
+       "pulse_duration_ms": 1300.0,
+       "refresh_command_limit": 1,
+       "full_pulse_refresh_commands": 10,
+       "observed_metres_per_pulse": 0.4734,
+       "target_nonzero_writes": 2
+      },
+      "motion_refresh": {
+       "refresh_enabled": true,
+       "refresh_interval_ms": 200,
+       "refresh_commands_sent": 1,
+       "refresh_command_limit": 1,
+       "refresh_write_durations_ms": [
+        239.926
+       ],
+       "max_refresh_commands": 1,
+       "elapsed_ms": 440.294
+      },
+      "stop_result": {
+       "attempted": true,
+       "ok": true,
+       "error": null,
+       "coordinator_method": "async_stop_manual_motion",
+       "use_wifi": false,
+       "transport_preference": "ble_preferred",
+       "ack": {
+        "movement_ok": true
+       },
+       "duration_ms": 101.423
+      },
+      "post_command_feedback_refresh": {
+       "method": "request_reports_count_5",
+       "settle_seconds": 0.0,
+       "ok": true,
+       "error": null,
+       "duration_ms": 0.402
+      },
+      "position_settled": true,
+      "position_moved": true,
+      "position_settle_wait_seconds": 3.01,
+      "position_feed_stale": false,
+      "position_settle_polls": 3,
+      "post_feedback_queue_settle": {
+       "live": true,
+       "reason": null,
+       "is_connected": true,
+       "is_usable": true,
+       "cooldown_active": false,
+       "cooldown_remaining_seconds": 0.0,
+       "last_send_age_seconds": 0.1,
+       "queue_depth": 0,
+       "queue_dispatch_paused": false,
+       "saga_active": false,
+       "stall_threshold_seconds": 15.0,
+       "queue_depth_limit": 0,
+       "duration_ms": 100.242
+      },
+      "position_source_comparison": {
+       "locations_xy": [
+        4.2954,
+        -3.8079
+       ],
+       "locations_stale_zero": false,
+       "mowing_state_xy": [
+        0.0,
+        0.0
+       ],
+       "agreement_m": 5.7403,
+       "rtk_status": 0,
+       "pos_level": 0,
+       "pos_type": 0,
+       "zone_hash": 0
+      },
+      "post_settle_feedback": {
+       "source": "position_settle",
+       "additional_wait_seconds": 0.0,
+       "requested_sample_delays_skipped": [
+        0.0,
+        3.0
+       ]
+      },
+      "final_approach_observation": {
+       "measured_distance": 0.07379220826076445,
+       "nonzero_writes": 2,
+       "normalised_metres_per_eleven_writes": 0.4059
+      }
+     }
+    ],
+    "samples": [
+     {
+      "label": "initial",
+      "telemetry": {
+       "online": true,
+       "work_mode": 11,
+       "work_mode_label": "MODE_READY",
+       "charge_state": 0,
+       "charge_state_label": "not_charging",
+       "position": {
+        "x": 4.7113,
+        "y": -3.362,
+        "toward": -136.5265,
+        "source": "report_data.locations[0]",
+        "pos_level": 1,
+        "pos_level_label": "SINGLE",
+        "rtk_status": 4,
+        "rtk_status_label": "Fix",
+        "pos_type": 1,
+        "pos_type_label": "AREA_INSIDE",
+        "zone_hash": "1343645155037768237",
+        "map_bol_hash": "3192426378327374167",
+        "area_name": "Backyard Right",
+        "valid_for_motion": true
+       },
+       "position_candidates": [
+        {
+         "source": "mowing_state",
+         "x": 0.0,
+         "y": 0.0,
+         "toward": 0.0,
+         "pos_level": 0,
+         "pos_level_label": "FIX",
+         "rtk_status": 0,
+         "rtk_status_label": "None",
+         "pos_type": 0,
+         "pos_type_label": "AREA_OUT",
+         "zone_hash": 0,
+         "area_name": null,
+         "stale_zero_area_out": true,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.locations[0]",
+         "x": 4.7113,
+         "y": -3.362,
+         "toward": -136.5265,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "location_metadata",
+         "x": null,
+         "y": null,
+         "toward": -136,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": "1343645155037768237",
+         "area_name": "Backyard Right",
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.rtk",
+         "x": null,
+         "y": null,
+         "toward": null,
+         "pos_level": 1,
+         "pos_level_label": "SINGLE",
+         "rtk_status": 4,
+         "rtk_status_label": "Fix",
+         "pos_type": null,
+         "pos_type_label": null,
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        }
+       ],
+       "blade": {
+        "reported_state": 0,
+        "reported_state_label": "OFF",
+        "knife_status": null,
+        "current_cutter_mode": 0,
+        "current_cutter_rpm": 0
+       },
+       "transport": {
+        "ble_rssi": -64,
+        "wifi_rssi": -50,
+        "wifi_connect_status": null,
+        "iot_connect_status": null,
+        "connection_label": "WIFI/BLE"
+       }
+      }
+     },
+     {
+      "label": "linear_1_position_settled",
+      "command_index": 1,
+      "delay_seconds": 3.01,
+      "source": "position_settle",
+      "telemetry": {
+       "online": true,
+       "work_mode": 11,
+       "work_mode_label": "MODE_READY",
+       "charge_state": 0,
+       "charge_state_label": "not_charging",
+       "position": {
+        "x": 4.4151,
+        "y": -3.6761,
+        "toward": -137.6495,
+        "source": "report_data.locations[0]",
+        "pos_level": 1,
+        "pos_level_label": "SINGLE",
+        "rtk_status": 4,
+        "rtk_status_label": "Fix",
+        "pos_type": 1,
+        "pos_type_label": "AREA_INSIDE",
+        "zone_hash": "1343645155037768237",
+        "map_bol_hash": "3192426378327374167",
+        "area_name": "Backyard Right",
+        "valid_for_motion": true
+       },
+       "position_candidates": [
+        {
+         "source": "mowing_state",
+         "x": 0.0,
+         "y": 0.0,
+         "toward": 0.0,
+         "pos_level": 0,
+         "pos_level_label": "FIX",
+         "rtk_status": 0,
+         "rtk_status_label": "None",
+         "pos_type": 0,
+         "pos_type_label": "AREA_OUT",
+         "zone_hash": 0,
+         "area_name": null,
+         "stale_zero_area_out": true,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.locations[0]",
+         "x": 4.4151,
+         "y": -3.6761,
+         "toward": -137.6495,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "location_metadata",
+         "x": null,
+         "y": null,
+         "toward": -137,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": "1343645155037768237",
+         "area_name": "Backyard Right",
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.rtk",
+         "x": null,
+         "y": null,
+         "toward": null,
+         "pos_level": 1,
+         "pos_level_label": "SINGLE",
+         "rtk_status": 4,
+         "rtk_status_label": "Fix",
+         "pos_type": null,
+         "pos_type_label": null,
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        }
+       ],
+       "blade": {
+        "reported_state": 0,
+        "reported_state_label": "OFF",
+        "knife_status": null,
+        "current_cutter_mode": 0,
+        "current_cutter_rpm": 0
+       },
+       "transport": {
+        "ble_rssi": -66,
+        "wifi_rssi": -51,
+        "wifi_connect_status": null,
+        "iot_connect_status": null,
+        "connection_label": "WIFI/BLE"
+       }
+      }
+     },
+     {
+      "label": "linear_2_position_settled",
+      "command_index": 2,
+      "delay_seconds": 3.01,
+      "source": "position_settle",
+      "telemetry": {
+       "online": true,
+       "work_mode": 11,
+       "work_mode_label": "MODE_READY",
+       "charge_state": 0,
+       "charge_state_label": "not_charging",
+       "position": {
+        "x": 4.3414,
+        "y": -3.7502,
+        "toward": -137.6495,
+        "source": "report_data.locations[0]",
+        "pos_level": 1,
+        "pos_level_label": "SINGLE",
+        "rtk_status": 4,
+        "rtk_status_label": "Fix",
+        "pos_type": 1,
+        "pos_type_label": "AREA_INSIDE",
+        "zone_hash": "1343645155037768237",
+        "map_bol_hash": "3192426378327374167",
+        "area_name": "Backyard Right",
+        "valid_for_motion": true
+       },
+       "position_candidates": [
+        {
+         "source": "mowing_state",
+         "x": 0.0,
+         "y": 0.0,
+         "toward": 0.0,
+         "pos_level": 0,
+         "pos_level_label": "FIX",
+         "rtk_status": 0,
+         "rtk_status_label": "None",
+         "pos_type": 0,
+         "pos_type_label": "AREA_OUT",
+         "zone_hash": 0,
+         "area_name": null,
+         "stale_zero_area_out": true,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.locations[0]",
+         "x": 4.3414,
+         "y": -3.7502,
+         "toward": -137.6495,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "location_metadata",
+         "x": null,
+         "y": null,
+         "toward": -137,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": "1343645155037768237",
+         "area_name": "Backyard Right",
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.rtk",
+         "x": null,
+         "y": null,
+         "toward": null,
+         "pos_level": 1,
+         "pos_level_label": "SINGLE",
+         "rtk_status": 4,
+         "rtk_status_label": "Fix",
+         "pos_type": null,
+         "pos_type_label": null,
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        }
+       ],
+       "blade": {
+        "reported_state": 0,
+        "reported_state_label": "OFF",
+        "knife_status": null,
+        "current_cutter_mode": 0,
+        "current_cutter_rpm": 0
+       },
+       "transport": {
+        "ble_rssi": -64,
+        "wifi_rssi": -48,
+        "wifi_connect_status": null,
+        "iot_connect_status": null,
+        "connection_label": "WIFI/BLE"
+       }
+      }
+     },
+     {
+      "label": "linear_3_position_settled",
+      "command_index": 3,
+      "delay_seconds": 3.01,
+      "source": "position_settle",
+      "telemetry": {
+       "online": true,
+       "work_mode": 11,
+       "work_mode_label": "MODE_READY",
+       "charge_state": 0,
+       "charge_state_label": "not_charging",
+       "position": {
+        "x": 4.2954,
+        "y": -3.8079,
+        "toward": -137.6495,
+        "source": "report_data.locations[0]",
+        "pos_level": 1,
+        "pos_level_label": "SINGLE",
+        "rtk_status": 4,
+        "rtk_status_label": "Fix",
+        "pos_type": 1,
+        "pos_type_label": "AREA_INSIDE",
+        "zone_hash": "1343645155037768237",
+        "map_bol_hash": "3192426378327374167",
+        "area_name": "Backyard Right",
+        "valid_for_motion": true
+       },
+       "position_candidates": [
+        {
+         "source": "mowing_state",
+         "x": 0.0,
+         "y": 0.0,
+         "toward": 0.0,
+         "pos_level": 0,
+         "pos_level_label": "FIX",
+         "rtk_status": 0,
+         "rtk_status_label": "None",
+         "pos_type": 0,
+         "pos_type_label": "AREA_OUT",
+         "zone_hash": 0,
+         "area_name": null,
+         "stale_zero_area_out": true,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.locations[0]",
+         "x": 4.2954,
+         "y": -3.8079,
+         "toward": -137.6495,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "location_metadata",
+         "x": null,
+         "y": null,
+         "toward": -137,
+         "pos_level": null,
+         "pos_level_label": null,
+         "rtk_status": null,
+         "rtk_status_label": null,
+         "pos_type": 1,
+         "pos_type_label": "AREA_INSIDE",
+         "zone_hash": "1343645155037768237",
+         "area_name": "Backyard Right",
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        },
+        {
+         "source": "report_data.rtk",
+         "x": null,
+         "y": null,
+         "toward": null,
+         "pos_level": 1,
+         "pos_level_label": "SINGLE",
+         "rtk_status": 4,
+         "rtk_status_label": "Fix",
+         "pos_type": null,
+         "pos_type_label": null,
+         "zone_hash": null,
+         "area_name": null,
+         "stale_zero_area_out": false,
+         "valid_for_motion": false
+        }
+       ],
+       "blade": {
+        "reported_state": 0,
+        "reported_state_label": "OFF",
+        "knife_status": null,
+        "current_cutter_mode": 0,
+        "current_cutter_rpm": 0
+       },
+       "transport": {
+        "ble_rssi": -64,
+        "wifi_rssi": -48,
+        "wifi_connect_status": null,
+        "iot_connect_status": null,
+        "connection_label": "WIFI/BLE"
+       }
+      }
+     }
+    ],
+    "phases": [
+     {
+      "name": "turn_to_target_heading",
+      "turn_mode": "vio",
+      "passed": true,
+      "result": {
+       "service": "vio_turn_to_heading",
+       "mode": "real_vio_turn_to_heading",
+       "dry_run": false,
+       "real_execution_scope": "vio_turn_to_heading_only",
+       "path_execution_allowed": false,
+       "target_vision_heading": 227.90230127035696,
+       "heading_tolerance_degrees": 18.0,
+       "angular_speed": 500,
+       "pulse_duration_ms": 1500,
+       "slow_pulse_duration_ms": 700,
+       "slow_threshold_degrees": 15.0,
+       "refresh_wait_seconds": 2.0,
+       "effective_poll_interval_seconds": 2.0,
+       "fresh_heading_timeout_seconds": 8.0,
+       "max_commands": 4,
+       "min_progress_degrees": 2.0,
+       "max_no_progress_pulses": 2,
+       "max_displacement_m": 0.3,
+       "invert_direction": false,
+       "motion_refresh_interval_ms": 200,
+       "motion_refresh_commands_sent": 0,
+       "refresh_cadence_broken_pulses": 0,
+       "prefer_ble": true,
+       "confirm_blades_off": true,
+       "confirm_clear_area": true,
+       "active_transport": "ble",
+       "initial_vision_heading": -132.77771101281903,
+       "initial_vio_state": 2,
+       "initial_vio_feed": {
+        "live": true,
+        "tracked_features": 80,
+        "brightness_raw": 1,
+        "brightness_label": "Light"
+       },
+       "initial_heading_error_degrees": 0.68,
+       "safety_gates": [
+        {
+         "name": "stop_primitive_available",
+         "passed": true,
+         "detail": "Coordinator must expose async_stop_manual_motion()."
+        },
+        {
+         "name": "ble_transport_required",
+         "passed": true,
+         "detail": "Real closed-loop motion requires the BLE transport for responsive telemetry; cloud/Wi-Fi lag is unsafe for guarded path execution. BLE must also report itself usable -- being selected for routing does not mean a command can be delivered."
+        },
+        {
+         "name": "ble_link_live",
+         "passed": true,
+         "detail": "Real motion requires a conservative BLE preflight -- a live client, an open dispatch gate, an empty command queue, and a recent outbound attempt. 'Usable' only means BLE is eligible for routing; it stays True while the command queue is gated and commands (including the mandatory stop that bounds a pulse) accumulate undelivered. The send path separately waits for confirmed queue start and GATT-write completion. See docs/pymammotion-ble-slot-leak-bug.md.",
+         "diagnostics": {
+          "live": true,
+          "reason": null,
+          "is_connected": true,
+          "is_usable": true,
+          "cooldown_active": false,
+          "cooldown_remaining_seconds": 0.0,
+          "last_send_age_seconds": 3.2,
+          "queue_depth": 0,
+          "queue_dispatch_paused": false,
+          "saga_active": false,
+          "stall_threshold_seconds": 15.0,
+          "queue_depth_limit": 0
+         }
+        },
+        {
+         "name": "operator_confirmed_blades_off",
+         "passed": true,
+         "detail": "Real pulse requires confirm_blades_off=true."
+        },
+        {
+         "name": "operator_confirmed_clear_area",
+         "passed": true,
+         "detail": "Real pulse requires confirm_clear_area=true."
+        },
+        {
+         "name": "mower_reports_blades_off",
+         "passed": true,
+         "detail": "Real pulse requires blade state off and cutter RPM zero/unknown."
+        },
+        {
+         "name": "mower_ready",
+         "passed": true,
+         "detail": "Real pulse requires the mower to be ready/paused, not mowing or charging."
+        },
+        {
+         "name": "not_docked_or_charging",
+         "passed": true,
+         "detail": "Real pulse requires the mower to be off the dock and not charging."
+        },
+        {
+         "name": "live_map_position_available",
+         "passed": true,
+         "detail": "Real pulse requires live map-local mower position."
+        },
+        {
+         "name": "position_area_inside",
+         "passed": true,
+         "detail": "Real pulse requires AREA_INSIDE, TURN_AREA_INSIDE, or CHANNEL_AREA_OVERLAP and a nonzero known zone hash."
+        },
+        {
+         "name": "map_position_nonzero",
+         "passed": true,
+         "detail": "Real pulse requires nonzero map-local x/y coordinates."
+        }
+       ],
+       "runtime_safety": {
+        "allowed_for_manual_motion": true,
+        "blockers": [],
+        "blade_safe_for_motion": true,
+        "active_mowing_detected": false,
+        "active_route_detected": false,
+        "active_route_status": {
+         "route_present": false,
+         "progress_present": false,
+         "progress_is_active": false,
+         "blocks_motion": false,
+         "reason": "no_route",
+         "ha_state": "paused",
+         "work_mode_label": "MODE_READY"
+        },
+        "position_valid_for_motion": true,
+        "rtk_report_age_seconds": null,
+        "rtk_report_quiet_threshold_seconds": 1800.0,
+        "rtk_report_quiet": false,
+        "rtk_status_label": "Fix",
+        "rtk_degraded": false,
+        "rtk_degraded_override": false
+       },
+       "blockers": [],
+       "would_send": false,
+       "planned_command": {
+        "command": "send_movement",
+        "kwargs": {
+         "linear_speed": 0,
+         "angular_speed": -500
+        }
+       },
+       "commands_sent": 0,
+       "command_results": [],
+       "final_vision_heading": -132.77771101281903,
+       "final_heading_error_degrees": 0.68,
+       "final_vio_feed": {
+        "live": true,
+        "tracked_features": 80,
+        "brightness_raw": 1,
+        "brightness_label": "Light"
+       },
+       "final_displacement_m": 0.0,
+       "turn_degrees_per_second": 37.0,
+       "turn_feasibility": null,
+       "stop_reason": "target_heading_reached"
+      }
+     },
+     {
+      "name": "linear_forward_to_target",
+      "passed": true,
+      "result": {
+       "commands_sent": 3,
+       "stop_reason": "target_reached",
+       "progress_diagnostics": [
+        {
+         "status": "path_progress",
+         "passed": true,
+         "action": "forward",
+         "path_progress_distance": 0.358378111463847,
+         "expected_target_heading_degrees": 225.07109455738114,
+         "movement_vector_heading_degrees": 227.14702095176335,
+         "heading_progress": true,
+         "min_progress_distance": 0.0025,
+         "min_heading_change_degrees": 0.0,
+         "command_index": 1,
+         "measured_delta": {
+          "distance": 0.3586134687933515,
+          "dx": -0.2439,
+          "dy": -0.26290000000000013,
+          "heading_change_degrees": -1.1230000000000473
+         }
+        },
+        {
+         "status": "path_progress",
+         "passed": true,
+         "action": "forward",
+         "path_progress_distance": 0.10438112371501715,
+         "expected_target_heading_degrees": 222.30093310561594,
+         "movement_vector_heading_degrees": 225.15506262416326,
+         "heading_progress": true,
+         "min_progress_distance": 0.0025,
+         "min_heading_change_degrees": 0.0,
+         "command_index": 2,
+         "measured_delta": {
+          "distance": 0.1045107649957647,
+          "dx": -0.07369999999999965,
+          "dy": -0.07410000000000005,
+          "heading_change_degrees": 0.0
+         }
+        },
+        {
+         "status": "path_progress",
+         "passed": true,
+         "action": "forward",
+         "path_progress_distance": 0.07244888066874386,
+         "expected_target_heading_degrees": 220.48795002626622,
+         "movement_vector_heading_degrees": 231.4372003804308,
+         "heading_progress": true,
+         "min_progress_distance": 0.0025,
+         "min_heading_change_degrees": 0.0,
+         "command_index": 3,
+         "measured_delta": {
+          "distance": 0.07379220826076445,
+          "dx": -0.04600000000000026,
+          "dy": -0.057700000000000085,
+          "heading_change_degrees": 0.0
+         }
+        }
+       ]
+      }
+     }
+    ],
+    "progress_diagnostics": [
+     {
+      "status": "path_progress",
+      "passed": true,
+      "action": "forward",
+      "path_progress_distance": 0.358378111463847,
+      "expected_target_heading_degrees": 225.07109455738114,
+      "movement_vector_heading_degrees": 227.14702095176335,
+      "heading_progress": true,
+      "min_progress_distance": 0.0025,
+      "min_heading_change_degrees": 0.0,
+      "command_index": 1,
+      "measured_delta": {
+       "distance": 0.3586134687933515,
+       "dx": -0.2439,
+       "dy": -0.26290000000000013,
+       "heading_change_degrees": -1.1230000000000473
+      }
+     },
+     {
+      "status": "path_progress",
+      "passed": true,
+      "action": "forward",
+      "path_progress_distance": 0.10438112371501715,
+      "expected_target_heading_degrees": 222.30093310561594,
+      "movement_vector_heading_degrees": 225.15506262416326,
+      "heading_progress": true,
+      "min_progress_distance": 0.0025,
+      "min_heading_change_degrees": 0.0,
+      "command_index": 2,
+      "measured_delta": {
+       "distance": 0.1045107649957647,
+       "dx": -0.07369999999999965,
+       "dy": -0.07410000000000005,
+       "heading_change_degrees": 0.0
+      }
+     },
+     {
+      "status": "path_progress",
+      "passed": true,
+      "action": "forward",
+      "path_progress_distance": 0.07244888066874386,
+      "expected_target_heading_degrees": 220.48795002626622,
+      "movement_vector_heading_degrees": 231.4372003804308,
+      "heading_progress": true,
+      "min_progress_distance": 0.0025,
+      "min_heading_change_degrees": 0.0,
+      "command_index": 3,
+      "measured_delta": {
+       "distance": 0.07379220826076445,
+       "dx": -0.04600000000000026,
+       "dy": -0.057700000000000085,
+       "heading_change_degrees": 0.0
+      }
+     }
+    ],
+    "completion_status": {
+     "complete": true,
+     "target_index": null,
+     "distance_to_target": null,
+     "waypoint_distances": [
+      {
+       "index": 0,
+       "distance": 0.6097537371759191
+      },
+      {
+       "index": 1,
+       "distance": 0.09310005370567696
+      }
+     ],
+     "reason": "path_complete"
+    },
+    "stop_reason": "target_reached",
+    "linear_execution_mode": "loop_to_tolerance",
+    "effective_linear_ceiling": 14,
+    "linear_distance_ceiling": 1.2537012881863046
+   }
+  }
+ ],
+ "initial_telemetry": {
+  "online": true,
+  "work_mode": 11,
+  "work_mode_label": "MODE_READY",
+  "charge_state": 0,
+  "charge_state_label": "not_charging",
+  "position": {
+   "x": 4.7113,
+   "y": -3.362,
+   "toward": -136.5265,
+   "source": "report_data.locations[0]",
+   "pos_level": 1,
+   "pos_level_label": "SINGLE",
+   "rtk_status": 4,
+   "rtk_status_label": "Fix",
+   "pos_type": 1,
+   "pos_type_label": "AREA_INSIDE",
+   "zone_hash": "1343645155037768237",
+   "map_bol_hash": "3192426378327374167",
+   "area_name": "Backyard Right",
+   "valid_for_motion": true
+  },
+  "position_candidates": [
+   {
+    "source": "mowing_state",
+    "x": 0.0,
+    "y": 0.0,
+    "toward": 0.0,
+    "pos_level": 0,
+    "pos_level_label": "FIX",
+    "rtk_status": 0,
+    "rtk_status_label": "None",
+    "pos_type": 0,
+    "pos_type_label": "AREA_OUT",
+    "zone_hash": 0,
+    "area_name": null,
+    "stale_zero_area_out": true,
+    "valid_for_motion": false
+   },
+   {
+    "source": "report_data.locations[0]",
+    "x": 4.7113,
+    "y": -3.362,
+    "toward": -136.5265,
+    "pos_level": null,
+    "pos_level_label": null,
+    "rtk_status": null,
+    "rtk_status_label": null,
+    "pos_type": 1,
+    "pos_type_label": "AREA_INSIDE",
+    "zone_hash": null,
+    "area_name": null,
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   },
+   {
+    "source": "location_metadata",
+    "x": null,
+    "y": null,
+    "toward": -136,
+    "pos_level": null,
+    "pos_level_label": null,
+    "rtk_status": null,
+    "rtk_status_label": null,
+    "pos_type": 1,
+    "pos_type_label": "AREA_INSIDE",
+    "zone_hash": "1343645155037768237",
+    "area_name": "Backyard Right",
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   },
+   {
+    "source": "report_data.rtk",
+    "x": null,
+    "y": null,
+    "toward": null,
+    "pos_level": 1,
+    "pos_level_label": "SINGLE",
+    "rtk_status": 4,
+    "rtk_status_label": "Fix",
+    "pos_type": null,
+    "pos_type_label": null,
+    "zone_hash": null,
+    "area_name": null,
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   }
+  ],
+  "blade": {
+   "reported_state": 0,
+   "reported_state_label": "OFF",
+   "knife_status": null,
+   "current_cutter_mode": 0,
+   "current_cutter_rpm": 0
+  },
+  "transport": {
+   "ble_rssi": -64,
+   "wifi_rssi": -50,
+   "wifi_connect_status": null,
+   "iot_connect_status": null,
+   "connection_label": "WIFI/BLE"
+  }
+ },
+ "final_telemetry": {
+  "online": true,
+  "work_mode": 11,
+  "work_mode_label": "MODE_READY",
+  "charge_state": 0,
+  "charge_state_label": "not_charging",
+  "position": {
+   "x": 4.2954,
+   "y": -3.8079,
+   "toward": -137.6495,
+   "source": "report_data.locations[0]",
+   "pos_level": 1,
+   "pos_level_label": "SINGLE",
+   "rtk_status": 4,
+   "rtk_status_label": "Fix",
+   "pos_type": 1,
+   "pos_type_label": "AREA_INSIDE",
+   "zone_hash": "1343645155037768237",
+   "map_bol_hash": "3192426378327374167",
+   "area_name": "Backyard Right",
+   "valid_for_motion": true
+  },
+  "position_candidates": [
+   {
+    "source": "mowing_state",
+    "x": 0.0,
+    "y": 0.0,
+    "toward": 0.0,
+    "pos_level": 0,
+    "pos_level_label": "FIX",
+    "rtk_status": 0,
+    "rtk_status_label": "None",
+    "pos_type": 0,
+    "pos_type_label": "AREA_OUT",
+    "zone_hash": 0,
+    "area_name": null,
+    "stale_zero_area_out": true,
+    "valid_for_motion": false
+   },
+   {
+    "source": "report_data.locations[0]",
+    "x": 4.2954,
+    "y": -3.8079,
+    "toward": -137.6495,
+    "pos_level": null,
+    "pos_level_label": null,
+    "rtk_status": null,
+    "rtk_status_label": null,
+    "pos_type": 1,
+    "pos_type_label": "AREA_INSIDE",
+    "zone_hash": null,
+    "area_name": null,
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   },
+   {
+    "source": "location_metadata",
+    "x": null,
+    "y": null,
+    "toward": -137,
+    "pos_level": null,
+    "pos_level_label": null,
+    "rtk_status": null,
+    "rtk_status_label": null,
+    "pos_type": 1,
+    "pos_type_label": "AREA_INSIDE",
+    "zone_hash": "1343645155037768237",
+    "area_name": "Backyard Right",
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   },
+   {
+    "source": "report_data.rtk",
+    "x": null,
+    "y": null,
+    "toward": null,
+    "pos_level": 1,
+    "pos_level_label": "SINGLE",
+    "rtk_status": 4,
+    "rtk_status_label": "Fix",
+    "pos_type": null,
+    "pos_type_label": null,
+    "zone_hash": null,
+    "area_name": null,
+    "stale_zero_area_out": false,
+    "valid_for_motion": false
+   }
+  ],
+  "blade": {
+   "reported_state": 0,
+   "reported_state_label": "OFF",
+   "knife_status": null,
+   "current_cutter_mode": 0,
+   "current_cutter_rpm": 0
+  },
+  "transport": {
+   "ble_rssi": -64,
+   "wifi_rssi": -48,
+   "wifi_connect_status": null,
+   "iot_connect_status": null,
+   "connection_label": "WIFI/BLE"
+  }
+ },
+ "runtime_safety": {
+  "allowed_for_manual_motion": true,
+  "blockers": [],
+  "blade_safe_for_motion": true,
+  "active_mowing_detected": false,
+  "active_route_detected": false,
+  "active_route_status": {
+   "route_present": false,
+   "progress_present": false,
+   "progress_is_active": false,
+   "blocks_motion": false,
+   "reason": "no_route",
+   "ha_state": "paused",
+   "work_mode_label": "MODE_READY"
+  },
+  "position_valid_for_motion": true,
+  "rtk_report_age_seconds": null,
+  "rtk_report_quiet_threshold_seconds": 1800.0,
+  "rtk_report_quiet": false,
+  "rtk_status_label": "Fix",
+  "rtk_degraded": false,
+  "rtk_degraded_override": false
+ },
+ "safety_gates": [
+  {
+   "name": "stop_primitive_available",
+   "passed": true,
+   "detail": "Coordinator must expose async_stop_manual_motion()."
+  },
+  {
+   "name": "ble_transport_required",
+   "passed": true,
+   "detail": "Real closed-loop motion requires the BLE transport for responsive telemetry; cloud/Wi-Fi lag is unsafe for guarded path execution. BLE must also report itself usable -- being selected for routing does not mean a command can be delivered."
+  },
+  {
+   "name": "ble_link_live",
+   "passed": true,
+   "detail": "Real motion requires a conservative BLE preflight -- a live client, an open dispatch gate, an empty command queue, and a recent outbound attempt. 'Usable' only means BLE is eligible for routing; it stays True while the command queue is gated and commands (including the mandatory stop that bounds a pulse) accumulate undelivered. The send path separately waits for confirmed queue start and GATT-write completion. See docs/pymammotion-ble-slot-leak-bug.md.",
+   "diagnostics": {
+    "live": true,
+    "reason": null,
+    "is_connected": true,
+    "is_usable": true,
+    "cooldown_active": false,
+    "cooldown_remaining_seconds": 0.0,
+    "last_send_age_seconds": 0.6,
+    "queue_depth": 0,
+    "queue_dispatch_paused": false,
+    "saga_active": false,
+    "stall_threshold_seconds": 15.0,
+    "queue_depth_limit": 0
+   }
+  },
+  {
+   "name": "operator_confirmed_blades_off",
+   "passed": true,
+   "detail": "Real pulse requires confirm_blades_off=true."
+  },
+  {
+   "name": "operator_confirmed_clear_area",
+   "passed": true,
+   "detail": "Real pulse requires confirm_clear_area=true."
+  },
+  {
+   "name": "mower_reports_blades_off",
+   "passed": true,
+   "detail": "Real pulse requires blade state off and cutter RPM zero/unknown."
+  },
+  {
+   "name": "mower_ready",
+   "passed": true,
+   "detail": "Real pulse requires the mower to be ready/paused, not mowing or charging."
+  },
+  {
+   "name": "not_docked_or_charging",
+   "passed": true,
+   "detail": "Real pulse requires the mower to be off the dock and not charging."
+  },
+  {
+   "name": "live_map_position_available",
+   "passed": true,
+   "detail": "Real pulse requires live map-local mower position."
+  },
+  {
+   "name": "position_area_inside",
+   "passed": true,
+   "detail": "Real pulse requires AREA_INSIDE, TURN_AREA_INSIDE, or CHANNEL_AREA_OVERLAP and a nonzero known zone hash."
+  },
+  {
+   "name": "map_position_nonzero",
+   "passed": true,
+   "detail": "Real pulse requires nonzero map-local x/y coordinates."
+  }
+ ],
+ "blockers": [],
+ "stop_reason": "target_reached",
+ "failed_segment_index": null,
+ "junction_turn_feasibility": []
+}

--- a/docs/evidence-night-go-card-beta54-20260814T180345Z.json
+++ b/docs/evidence-night-go-card-beta54-20260814T180345Z.json
@@ -1,0 +1,8757 @@
+{
+  "valid": true,
+  "errors": [],
+  "warnings": [],
+  "coordinate_system": "mower_map_xy",
+  "blade_mode": "off",
+  "speed": 0.2,
+  "area_hash": "1343645155037768237",
+  "point_count": 2,
+  "distance": 0.7391380114701183,
+  "points": [
+    {
+      "x": 4.954,
+      "y": -2.643
+    },
+    {
+      "x": 5.692,
+      "y": -2.602
+    }
+  ],
+  "geojson": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "type_name": "custom_path_start",
+          "Name": "Start",
+          "marker": "start"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            4.954,
+            -2.643
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "type_name": "custom_path",
+          "Name": "Custom path",
+          "valid": true,
+          "distance": 0.7391380114701183,
+          "color": "#22c55e",
+          "weight": 3
+        },
+        "geometry": {
+          "type": "LineString",
+          "coordinates": [
+            [
+              4.954,
+              -2.643
+            ],
+            [
+              5.692,
+              -2.602
+            ]
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "type_name": "custom_path_end",
+          "Name": "End",
+          "marker": "end"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            5.692,
+            -2.602
+          ]
+        }
+      }
+    ]
+  },
+  "path": {
+    "coordinate_system": "mower_map_xy",
+    "points": [
+      {
+        "x": 4.954,
+        "y": -2.643
+      },
+      {
+        "x": 5.692,
+        "y": -2.602
+      }
+    ],
+    "distance": 0.7391380114701183
+  },
+  "service": "raw_pymammotion_execute_vector_segment",
+  "mode": "real_raw_vector_segment",
+  "dry_run": false,
+  "would_send": true,
+  "real_execution_scope": "one_segment_turn_then_forward_only",
+  "full_path_execution_allowed": false,
+  "ready_for_multi_point": false,
+  "prefer_ble": true,
+  "transport_preference": "ble_preferred",
+  "ble_auto_recover": false,
+  "ble_recovery": null,
+  "linear_speed_fast": 400,
+  "linear_speed_slow": 200,
+  "slow_linear_threshold": 0.15,
+  "max_turn_commands": 4,
+  "max_linear_commands": 3,
+  "heading_tolerance_degrees": 8,
+  "angular_speed_fast": 180,
+  "angular_speed_slow": 180,
+  "slow_turn_threshold_degrees": 8,
+  "waypoint_tolerance": 0.08,
+  "min_progress_distance": 0.06,
+  "min_heading_change_degrees": 0.5,
+  "max_turn_translation_distance": 0.3,
+  "calibrated_forward_heading_offset_degrees": 116.5,
+  "max_linear_pulse_ceiling": null,
+  "max_no_progress_pulses": 3,
+  "final_approach_metres_per_pulse": 1.06,
+  "turn_degrees_per_second": 37,
+  "turn_pulse_duration_ms": 1500,
+  "linear_pulse_duration_ms": 3500,
+  "vio_turn_max_commands": 8,
+  "vio_angular_speed": 500,
+  "night_angular_speed": 500,
+  "toward_mirror_degrees": 90.13,
+  "vio_heading_offset_degrees": null,
+  "sample_delays": [
+    0,
+    5,
+    10,
+    20,
+    30,
+    45,
+    60
+  ],
+  "confirm_blades_off": true,
+  "confirm_clear_area": true,
+  "advisory_start": {
+    "x": 4.954,
+    "y": -2.643
+  },
+  "true_start": {
+    "x": 4.9541,
+    "y": -2.6429
+  },
+  "target": {
+    "x": 5.692,
+    "y": -2.602
+  },
+  "target_map_heading_degrees": 3.172519296959422,
+  "target_reported_heading_degrees": 86.95748070304057,
+  "target_heading_degrees": 86.95748070304057,
+  "heading_calibration": {
+    "model": "mirror",
+    "formula": "target_toward_heading = toward_mirror_degrees - target_map_heading",
+    "toward_mirror_degrees": 90.13,
+    "target_map_heading_degrees": 3.172519296959422,
+    "calibrated_forward_heading_offset_degrees": 116.5,
+    "calibrated_forward_heading_offset_applied": false,
+    "target_reported_heading_degrees": 86.95748070304057
+  },
+  "initial_linear_command_selection": {
+    "command": "send_movement",
+    "linear_speed": 400,
+    "angular_speed": 0,
+    "distance_to_target": 0.7390326244490155,
+    "speed_tier": "fast",
+    "slow_linear_threshold": 0.15,
+    "reason": "target_remaining"
+  },
+  "turn_mode": "night",
+  "vio": {
+    "initial_vio_state": null,
+    "initial_vio_feed": {
+      "live": null,
+      "tracked_features": null,
+      "brightness_raw": null,
+      "brightness_label": null
+    },
+    "initial_vision_heading": null,
+    "provided_offset_degrees": null,
+    "offset_degrees": null,
+    "offset_source": null,
+    "target_vision_heading": null,
+    "calibration": null,
+    "formula": "target_vision_heading = target_map_heading - (map_motion_heading - vision_heading)"
+  },
+  "initial_telemetry": {
+    "online": true,
+    "work_mode": 11,
+    "work_mode_label": "MODE_READY",
+    "charge_state": 0,
+    "charge_state_label": "not_charging",
+    "position": {
+      "x": 4.9541,
+      "y": -2.6429,
+      "toward": 173.9375,
+      "source": "report_data.locations[0]",
+      "pos_level": 1,
+      "pos_level_label": "SINGLE",
+      "rtk_status": 4,
+      "rtk_status_label": "Fix",
+      "pos_type": 1,
+      "pos_type_label": "AREA_INSIDE",
+      "zone_hash": "1343645155037768237",
+      "map_bol_hash": "3192426378327374167",
+      "area_name": "Backyard Right",
+      "valid_for_motion": true
+    },
+    "position_candidates": [
+      {
+        "source": "mowing_state",
+        "x": 0,
+        "y": 0,
+        "toward": 0,
+        "pos_level": 0,
+        "pos_level_label": "FIX",
+        "rtk_status": 0,
+        "rtk_status_label": "None",
+        "pos_type": 0,
+        "pos_type_label": "AREA_OUT",
+        "zone_hash": 0,
+        "area_name": null,
+        "stale_zero_area_out": true,
+        "valid_for_motion": false
+      },
+      {
+        "source": "report_data.locations[0]",
+        "x": 4.9541,
+        "y": -2.6429,
+        "toward": 173.9375,
+        "pos_level": null,
+        "pos_level_label": null,
+        "rtk_status": null,
+        "rtk_status_label": null,
+        "pos_type": 1,
+        "pos_type_label": "AREA_INSIDE",
+        "zone_hash": null,
+        "area_name": null,
+        "stale_zero_area_out": false,
+        "valid_for_motion": false
+      },
+      {
+        "source": "location_metadata",
+        "x": null,
+        "y": null,
+        "toward": 173,
+        "pos_level": null,
+        "pos_level_label": null,
+        "rtk_status": null,
+        "rtk_status_label": null,
+        "pos_type": 1,
+        "pos_type_label": "AREA_INSIDE",
+        "zone_hash": "1343645155037768237",
+        "area_name": "Backyard Right",
+        "stale_zero_area_out": false,
+        "valid_for_motion": false
+      },
+      {
+        "source": "report_data.rtk",
+        "x": null,
+        "y": null,
+        "toward": null,
+        "pos_level": 1,
+        "pos_level_label": "SINGLE",
+        "rtk_status": 4,
+        "rtk_status_label": "Fix",
+        "pos_type": null,
+        "pos_type_label": null,
+        "zone_hash": null,
+        "area_name": null,
+        "stale_zero_area_out": false,
+        "valid_for_motion": false
+      }
+    ],
+    "blade": {
+      "reported_state": 0,
+      "reported_state_label": "OFF",
+      "knife_status": null,
+      "current_cutter_mode": 0,
+      "current_cutter_rpm": 0
+    },
+    "transport": {
+      "ble_rssi": -64,
+      "wifi_rssi": -55,
+      "wifi_connect_status": null,
+      "iot_connect_status": null,
+      "connection_label": "WIFI/BLE"
+    }
+  },
+  "final_telemetry": {
+    "online": true,
+    "work_mode": 11,
+    "work_mode_label": "MODE_READY",
+    "charge_state": 0,
+    "charge_state_label": "not_charging",
+    "position": {
+      "x": 5.8041,
+      "y": -2.6358,
+      "toward": 89.1396,
+      "source": "report_data.locations[0]",
+      "pos_level": 1,
+      "pos_level_label": "SINGLE",
+      "rtk_status": 4,
+      "rtk_status_label": "Fix",
+      "pos_type": 1,
+      "pos_type_label": "AREA_INSIDE",
+      "zone_hash": "1343645155037768237",
+      "map_bol_hash": "3192426378327374167",
+      "area_name": "Backyard Right",
+      "valid_for_motion": true
+    },
+    "position_candidates": [
+      {
+        "source": "mowing_state",
+        "x": 0,
+        "y": 0,
+        "toward": 0,
+        "pos_level": 0,
+        "pos_level_label": "FIX",
+        "rtk_status": 0,
+        "rtk_status_label": "None",
+        "pos_type": 0,
+        "pos_type_label": "AREA_OUT",
+        "zone_hash": 0,
+        "area_name": null,
+        "stale_zero_area_out": true,
+        "valid_for_motion": false
+      },
+      {
+        "source": "report_data.locations[0]",
+        "x": 5.8041,
+        "y": -2.6358,
+        "toward": 89.1396,
+        "pos_level": null,
+        "pos_level_label": null,
+        "rtk_status": null,
+        "rtk_status_label": null,
+        "pos_type": 1,
+        "pos_type_label": "AREA_INSIDE",
+        "zone_hash": null,
+        "area_name": null,
+        "stale_zero_area_out": false,
+        "valid_for_motion": false
+      },
+      {
+        "source": "location_metadata",
+        "x": null,
+        "y": null,
+        "toward": 89,
+        "pos_level": null,
+        "pos_level_label": null,
+        "rtk_status": null,
+        "rtk_status_label": null,
+        "pos_type": 1,
+        "pos_type_label": "AREA_INSIDE",
+        "zone_hash": "1343645155037768237",
+        "area_name": "Backyard Right",
+        "stale_zero_area_out": false,
+        "valid_for_motion": false
+      },
+      {
+        "source": "report_data.rtk",
+        "x": null,
+        "y": null,
+        "toward": null,
+        "pos_level": 1,
+        "pos_level_label": "SINGLE",
+        "rtk_status": 4,
+        "rtk_status_label": "Fix",
+        "pos_type": null,
+        "pos_type_label": null,
+        "zone_hash": null,
+        "area_name": null,
+        "stale_zero_area_out": false,
+        "valid_for_motion": false
+      }
+    ],
+    "blade": {
+      "reported_state": 0,
+      "reported_state_label": "OFF",
+      "knife_status": null,
+      "current_cutter_mode": 0,
+      "current_cutter_rpm": 0
+    },
+    "transport": {
+      "ble_rssi": -58,
+      "wifi_rssi": -58,
+      "wifi_connect_status": null,
+      "iot_connect_status": null,
+      "connection_label": "WIFI/BLE"
+    }
+  },
+  "runtime_safety": {
+    "allowed_for_manual_motion": true,
+    "blockers": [],
+    "blade_safe_for_motion": true,
+    "active_mowing_detected": false,
+    "active_route_detected": false,
+    "active_route_status": {
+      "route_present": false,
+      "progress_present": false,
+      "progress_is_active": false,
+      "blocks_motion": false,
+      "reason": "no_route",
+      "ha_state": "paused",
+      "work_mode_label": "MODE_READY"
+    },
+    "position_valid_for_motion": true,
+    "rtk_report_age_seconds": null,
+    "rtk_report_quiet_threshold_seconds": 1800,
+    "rtk_report_quiet": false,
+    "rtk_status_label": "Fix",
+    "rtk_degraded": false,
+    "rtk_degraded_override": false
+  },
+  "queue_settle": {
+    "live": true,
+    "reason": null,
+    "is_connected": true,
+    "is_usable": true,
+    "cooldown_active": false,
+    "cooldown_remaining_seconds": 0,
+    "last_send_age_seconds": 1.8,
+    "queue_depth": 0,
+    "queue_dispatch_paused": false,
+    "saga_active": false,
+    "stall_threshold_seconds": 15,
+    "queue_depth_limit": 0
+  },
+  "safety_gates": [
+    {
+      "name": "stop_primitive_available",
+      "passed": true,
+      "detail": "Coordinator must expose async_stop_manual_motion()."
+    },
+    {
+      "name": "ble_transport_required",
+      "passed": true,
+      "detail": "Real closed-loop motion requires the BLE transport for responsive telemetry; cloud/Wi-Fi lag is unsafe for guarded path execution. BLE must also report itself usable -- being selected for routing does not mean a command can be delivered."
+    },
+    {
+      "name": "ble_link_live",
+      "passed": true,
+      "detail": "Real motion requires a conservative BLE preflight -- a live client, an open dispatch gate, an empty command queue, and a recent outbound attempt. 'Usable' only means BLE is eligible for routing; it stays True while the command queue is gated and commands (including the mandatory stop that bounds a pulse) accumulate undelivered. The send path separately waits for confirmed queue start and GATT-write completion. See docs/pymammotion-ble-slot-leak-bug.md.",
+      "diagnostics": {
+        "live": true,
+        "reason": null,
+        "is_connected": true,
+        "is_usable": true,
+        "cooldown_active": false,
+        "cooldown_remaining_seconds": 0,
+        "last_send_age_seconds": 1.8,
+        "queue_depth": 0,
+        "queue_dispatch_paused": false,
+        "saga_active": false,
+        "stall_threshold_seconds": 15,
+        "queue_depth_limit": 0
+      }
+    },
+    {
+      "name": "operator_confirmed_blades_off",
+      "passed": true,
+      "detail": "Real pulse requires confirm_blades_off=true."
+    },
+    {
+      "name": "operator_confirmed_clear_area",
+      "passed": true,
+      "detail": "Real pulse requires confirm_clear_area=true."
+    },
+    {
+      "name": "mower_reports_blades_off",
+      "passed": true,
+      "detail": "Real pulse requires blade state off and cutter RPM zero/unknown."
+    },
+    {
+      "name": "mower_ready",
+      "passed": true,
+      "detail": "Real pulse requires the mower to be ready/paused, not mowing or charging."
+    },
+    {
+      "name": "not_docked_or_charging",
+      "passed": true,
+      "detail": "Real pulse requires the mower to be off the dock and not charging."
+    },
+    {
+      "name": "live_map_position_available",
+      "passed": true,
+      "detail": "Real pulse requires live map-local mower position."
+    },
+    {
+      "name": "position_area_inside",
+      "passed": true,
+      "detail": "Real pulse requires AREA_INSIDE, TURN_AREA_INSIDE, or CHANNEL_AREA_OVERLAP and a nonzero known zone hash."
+    },
+    {
+      "name": "map_position_nonzero",
+      "passed": true,
+      "detail": "Real pulse requires nonzero map-local x/y coordinates."
+    },
+    {
+      "name": "night_requires_precise_rtk",
+      "passed": true,
+      "detail": "Night mode requires RTK Fix; saw Fix.",
+      "diagnostics": {
+        "rtk_status_label": "Fix",
+        "rtk_degraded": false
+      }
+    },
+    {
+      "name": "night_linear_loop_unsupported",
+      "passed": true,
+      "detail": "Night runs the fixed max_linear_commands budget; pass max_linear_pulse_ceiling: null."
+    },
+    {
+      "name": "night_segment_too_long",
+      "passed": true,
+      "detail": "Night runs a fixed 3-pulse budget with no mid-drive correction, so legs must be at most 1.0 m.",
+      "diagnostics": {
+        "segment_length_m": 0.7390326244490155,
+        "max_segment_length_m": 1
+      }
+    }
+  ],
+  "blockers": [],
+  "commands_sent": 6,
+  "turn_commands_sent": 3,
+  "linear_commands_sent": 3,
+  "motion_refresh_interval_ms": 200,
+  "motion_refresh_commands_sent": 9,
+  "app_speed_scale": {
+    "available": true,
+    "linear_speed": 400,
+    "angular_speed": 500,
+    "app_max_linear_speed": 850,
+    "app_max_angular_speed": 382,
+    "linear_fraction_of_app_max": 0.471,
+    "angular_fraction_of_app_max": 1.309,
+    "linear_above_app_max": false,
+    "angular_above_app_max": true
+  },
+  "calibration_commands_sent": 0,
+  "realignments": [],
+  "night_aim": [
+    {
+      "after_linear_pulse": 1,
+      "movement_vector_heading_degrees": 0.9191626009473453,
+      "bearing_to_target_degrees": 3.4070760191693807,
+      "measured_distance_m": 0.5298681817206992,
+      "distance_to_target_m": 0.2256390480391199,
+      "observed_toward_mirror_degrees": 91.27286260094735,
+      "aim_error_degrees": 2.488,
+      "decision": "drive_on_projects_inside_tolerance"
+    },
+    {
+      "after_linear_pulse": 2,
+      "movement_vector_heading_degrees": 0.42298129193369505,
+      "bearing_to_target_degrees": 9.257769838750107,
+      "measured_distance_m": 0.29800812069472205,
+      "distance_to_target_m": 0.08266135735638462,
+      "observed_toward_mirror_degrees": 89.5625812919337,
+      "aim_error_degrees": 8.835,
+      "decision": "drive_on_projects_inside_tolerance"
+    },
+    {
+      "after_linear_pulse": 3,
+      "movement_vector_heading_degrees": 0.4670748123137969,
+      "bearing_to_target_degrees": 155.63635563086268,
+      "measured_distance_m": 0.03680122280577139,
+      "distance_to_target_m": 0.11708479833009915,
+      "observed_toward_mirror_degrees": 89.6066748123138,
+      "decision": "below_aim_baseline"
+    }
+  ],
+  "command_results": [
+    {
+      "index": 1,
+      "attempted": true,
+      "ok": true,
+      "ack": null,
+      "error": null,
+      "duration_ms": 422.162,
+      "command": "send_movement",
+      "prefer_ble": true,
+      "kwargs": {
+        "linear_speed": 0,
+        "angular_speed": -500
+      },
+      "selection": {
+        "command": "send_movement",
+        "linear_speed": 0,
+        "angular_speed": -500,
+        "direction": "negative_heading",
+        "positive_heading_uses_positive_angular_speed": true,
+        "negative_heading_uses_negative_angular_speed": true,
+        "heading_error_degrees": -86.98001929695943,
+        "absolute_heading_error_degrees": 86.98001929695943,
+        "speed_tier": "fast",
+        "slow_turn_threshold_degrees": 8
+      },
+      "motion_refresh": {
+        "refresh_enabled": true,
+        "refresh_interval_ms": 200,
+        "refresh_commands_sent": 5,
+        "refresh_command_limit": null,
+        "refresh_write_durations_ms": [
+          187.29,
+          230.497,
+          208.532,
+          568.404,
+          305.598
+        ],
+        "max_refresh_commands": 7,
+        "elapsed_ms": 1717.278
+      },
+      "stop_result": {
+        "attempted": true,
+        "ok": true,
+        "error": null,
+        "coordinator_method": "async_stop_manual_motion",
+        "use_wifi": false,
+        "transport_preference": "ble_preferred",
+        "ack": {
+          "movement_ok": true
+        },
+        "duration_ms": 129.937
+      },
+      "post_command_feedback_refresh": {
+        "method": "request_reports_count_5",
+        "settle_seconds": 2,
+        "ok": true,
+        "error": null,
+        "duration_ms": 2001.463
+      }
+    },
+    {
+      "index": 2,
+      "attempted": true,
+      "ok": true,
+      "ack": null,
+      "error": null,
+      "duration_ms": 298.598,
+      "command": "send_movement",
+      "prefer_ble": true,
+      "kwargs": {
+        "linear_speed": 0,
+        "angular_speed": -500
+      },
+      "selection": {
+        "command": "send_movement",
+        "linear_speed": 0,
+        "angular_speed": -500,
+        "direction": "negative_heading",
+        "positive_heading_uses_positive_angular_speed": true,
+        "negative_heading_uses_negative_angular_speed": true,
+        "heading_error_degrees": -22.04501929695948,
+        "absolute_heading_error_degrees": 22.04501929695948,
+        "speed_tier": "fast",
+        "slow_turn_threshold_degrees": 8
+      },
+      "motion_refresh": {
+        "refresh_enabled": true,
+        "refresh_interval_ms": 200,
+        "refresh_commands_sent": 4,
+        "refresh_command_limit": null,
+        "refresh_write_durations_ms": [
+          292.575,
+          310.493,
+          416.159,
+          302.53
+        ],
+        "max_refresh_commands": 7,
+        "elapsed_ms": 1611.029
+      },
+      "stop_result": {
+        "attempted": true,
+        "ok": true,
+        "error": null,
+        "coordinator_method": "async_stop_manual_motion",
+        "use_wifi": false,
+        "transport_preference": "ble_preferred",
+        "ack": {
+          "movement_ok": true
+        },
+        "duration_ms": 136.399
+      },
+      "post_command_feedback_refresh": {
+        "method": "request_reports_count_5",
+        "settle_seconds": 2,
+        "ok": true,
+        "error": null,
+        "duration_ms": 2060.775
+      }
+    },
+    {
+      "index": 3,
+      "attempted": true,
+      "ok": true,
+      "ack": null,
+      "error": null,
+      "duration_ms": 68.981,
+      "command": "send_movement",
+      "prefer_ble": true,
+      "kwargs": {
+        "linear_speed": 0,
+        "angular_speed": 500
+      },
+      "selection": {
+        "command": "send_movement",
+        "linear_speed": 0,
+        "angular_speed": 500,
+        "direction": "positive_heading",
+        "positive_heading_uses_positive_angular_speed": true,
+        "negative_heading_uses_negative_angular_speed": true,
+        "heading_error_degrees": 36.685780703040564,
+        "absolute_heading_error_degrees": 36.685780703040564,
+        "speed_tier": "fast",
+        "slow_turn_threshold_degrees": 8
+      },
+      "motion_refresh": {
+        "refresh_enabled": true,
+        "refresh_interval_ms": 200,
+        "refresh_commands_sent": 4,
+        "refresh_command_limit": null,
+        "refresh_write_durations_ms": [
+          219.399,
+          737.895,
+          244.52,
+          181.715
+        ],
+        "max_refresh_commands": 7,
+        "elapsed_ms": 1584.984
+      },
+      "stop_result": {
+        "attempted": true,
+        "ok": true,
+        "error": null,
+        "coordinator_method": "async_stop_manual_motion",
+        "use_wifi": false,
+        "transport_preference": "ble_preferred",
+        "ack": {
+          "movement_ok": true
+        },
+        "duration_ms": 176.495
+      },
+      "post_command_feedback_refresh": {
+        "method": "request_reports_count_5",
+        "settle_seconds": 2,
+        "ok": true,
+        "error": null,
+        "duration_ms": 2000.838
+      }
+    },
+    {
+      "index": 1,
+      "phase": "linear_forward_to_target",
+      "attempted": true,
+      "ok": true,
+      "ack": null,
+      "error": null,
+      "duration_ms": 139.094,
+      "command": "send_movement",
+      "sent_at_utc": "2026-08-14T17:59:20.969789+00:00",
+      "prefer_ble": true,
+      "kwargs": {
+        "linear_speed": 400,
+        "angular_speed": 0
+      },
+      "selection": {
+        "command": "send_movement",
+        "linear_speed": 400,
+        "angular_speed": 0,
+        "distance_to_target": 0.7538324017976413,
+        "speed_tier": "fast",
+        "slow_linear_threshold": 0.15,
+        "reason": "target_remaining"
+      },
+      "final_approach": {
+        "applied": true,
+        "reason": "final_approach_bounded_by_refresh_count",
+        "distance_to_target": 0.7538324017976413,
+        "metres_per_pulse": 1.06,
+        "metres_per_pulse_source": "default",
+        "pulse_duration_ms": 3500,
+        "refresh_command_limit": 7,
+        "full_pulse_refresh_commands": 10,
+        "target_nonzero_writes": 8
+      },
+      "motion_refresh": {
+        "refresh_enabled": true,
+        "refresh_interval_ms": 200,
+        "refresh_commands_sent": 7,
+        "refresh_command_limit": 7,
+        "refresh_write_durations_ms": [
+          577.739,
+          651.598,
+          86.13,
+          257.794,
+          1531.48,
+          174.747,
+          142.804
+        ],
+        "max_refresh_commands": 7,
+        "elapsed_ms": 3623.494
+      },
+      "stop_result": {
+        "attempted": true,
+        "ok": true,
+        "error": null,
+        "coordinator_method": "async_stop_manual_motion",
+        "use_wifi": false,
+        "transport_preference": "ble_preferred",
+        "ack": {
+          "movement_ok": true
+        },
+        "duration_ms": 309.953
+      },
+      "post_command_feedback_refresh": {
+        "method": "request_reports_count_5",
+        "settle_seconds": 2,
+        "ok": true,
+        "error": null,
+        "duration_ms": 2000.756
+      },
+      "position_settled": true,
+      "position_moved": true,
+      "position_settle_wait_seconds": 1,
+      "position_feed_stale": false,
+      "position_settle_polls": 1,
+      "position_source_comparison": {
+        "locations_xy": [
+          5.4693,
+          -2.6383
+        ],
+        "locations_stale_zero": false,
+        "mowing_state_xy": [
+          0,
+          0
+        ],
+        "agreement_m": 6.0724,
+        "rtk_status": 0,
+        "pos_level": 0,
+        "pos_type": 0,
+        "zone_hash": 0
+      },
+      "final_approach_observation": {
+        "measured_distance": 0.5298681817206992,
+        "nonzero_writes": 8,
+        "normalised_metres_per_eleven_writes": 0.7286
+      }
+    },
+    {
+      "index": 2,
+      "phase": "linear_forward_to_target",
+      "attempted": true,
+      "ok": true,
+      "ack": null,
+      "error": null,
+      "duration_ms": 356.602,
+      "command": "send_movement",
+      "sent_at_utc": "2026-08-14T18:00:28.123067+00:00",
+      "prefer_ble": true,
+      "kwargs": {
+        "linear_speed": 400,
+        "angular_speed": 0
+      },
+      "selection": {
+        "command": "send_movement",
+        "linear_speed": 400,
+        "angular_speed": 0,
+        "distance_to_target": 0.2256390480391199,
+        "speed_tier": "fast",
+        "slow_linear_threshold": 0.15,
+        "reason": "target_remaining"
+      },
+      "final_approach": {
+        "applied": true,
+        "reason": "final_approach_bounded_by_refresh_count",
+        "distance_to_target": 0.2256390480391199,
+        "metres_per_pulse": 1.06,
+        "metres_per_pulse_source": "default_conservative_floor",
+        "pulse_duration_ms": 3500,
+        "refresh_command_limit": 2,
+        "full_pulse_refresh_commands": 10,
+        "observed_metres_per_pulse": 0.7286,
+        "target_nonzero_writes": 3
+      },
+      "motion_refresh": {
+        "refresh_enabled": true,
+        "refresh_interval_ms": 200,
+        "refresh_commands_sent": 2,
+        "refresh_command_limit": 2,
+        "refresh_write_durations_ms": [
+          242.419,
+          465.578
+        ],
+        "max_refresh_commands": 2,
+        "elapsed_ms": 908.295
+      },
+      "stop_result": {
+        "attempted": true,
+        "ok": true,
+        "error": null,
+        "coordinator_method": "async_stop_manual_motion",
+        "use_wifi": false,
+        "transport_preference": "ble_preferred",
+        "ack": {
+          "movement_ok": true
+        },
+        "duration_ms": 303.66
+      },
+      "post_command_feedback_refresh": {
+        "method": "request_reports_count_5",
+        "settle_seconds": 2,
+        "ok": true,
+        "error": null,
+        "duration_ms": 2001.344
+      },
+      "position_settled": true,
+      "position_moved": true,
+      "position_settle_wait_seconds": 1,
+      "position_feed_stale": false,
+      "position_settle_polls": 1,
+      "position_source_comparison": {
+        "locations_xy": [
+          5.7675,
+          -2.6369
+        ],
+        "locations_stale_zero": false,
+        "mowing_state_xy": [
+          0,
+          0
+        ],
+        "agreement_m": 6.3417,
+        "rtk_status": 0,
+        "pos_level": 0,
+        "pos_type": 0,
+        "zone_hash": 0
+      },
+      "final_approach_observation": {
+        "measured_distance": 0.29800812069472205,
+        "nonzero_writes": 3,
+        "normalised_metres_per_eleven_writes": 1.0927
+      }
+    },
+    {
+      "index": 3,
+      "phase": "linear_forward_to_target",
+      "attempted": true,
+      "ok": true,
+      "ack": null,
+      "error": null,
+      "duration_ms": 303.836,
+      "command": "send_movement",
+      "sent_at_utc": "2026-08-14T18:01:32.840228+00:00",
+      "prefer_ble": true,
+      "kwargs": {
+        "linear_speed": 200,
+        "angular_speed": 0
+      },
+      "selection": {
+        "command": "send_movement",
+        "linear_speed": 200,
+        "angular_speed": 0,
+        "distance_to_target": 0.08266135735638462,
+        "speed_tier": "slow",
+        "slow_linear_threshold": 0.15,
+        "reason": "target_remaining"
+      },
+      "final_approach": {
+        "applied": true,
+        "reason": "final_approach_bounded_by_refresh_count",
+        "distance_to_target": 0.08266135735638462,
+        "metres_per_pulse": 1.06,
+        "metres_per_pulse_source": "default",
+        "pulse_duration_ms": 3500,
+        "refresh_command_limit": 0,
+        "full_pulse_refresh_commands": 10,
+        "target_nonzero_writes": 1
+      },
+      "motion_refresh": {
+        "refresh_enabled": true,
+        "refresh_interval_ms": 200,
+        "refresh_commands_sent": 0,
+        "refresh_command_limit": 0,
+        "refresh_write_durations_ms": [],
+        "max_refresh_commands": 0,
+        "elapsed_ms": 0.006
+      },
+      "stop_result": {
+        "attempted": true,
+        "ok": true,
+        "error": null,
+        "coordinator_method": "async_stop_manual_motion",
+        "use_wifi": false,
+        "transport_preference": "ble_preferred",
+        "ack": {
+          "movement_ok": true
+        },
+        "duration_ms": 967.539
+      },
+      "post_command_feedback_refresh": {
+        "method": "request_reports_count_5",
+        "settle_seconds": 2,
+        "ok": true,
+        "error": null,
+        "duration_ms": 2000.9
+      },
+      "position_settled": true,
+      "position_moved": true,
+      "position_settle_wait_seconds": 1,
+      "position_feed_stale": false,
+      "position_settle_polls": 1,
+      "position_source_comparison": {
+        "locations_xy": [
+          5.8041,
+          -2.6358
+        ],
+        "locations_stale_zero": false,
+        "mowing_state_xy": [
+          0,
+          0
+        ],
+        "agreement_m": 6.3746,
+        "rtk_status": 0,
+        "pos_level": 0,
+        "pos_type": 0,
+        "zone_hash": 0
+      },
+      "final_approach_observation": {
+        "measured_distance": 0.03680122280577139,
+        "nonzero_writes": 1,
+        "normalised_metres_per_eleven_writes": 0.4048
+      }
+    }
+  ],
+  "samples": [
+    {
+      "label": "initial",
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9541,
+          "y": -2.6429,
+          "toward": 173.9375,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9541,
+            "y": -2.6429,
+            "toward": 173.9375,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 173,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -64,
+          "wifi_rssi": -55,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_1_sample_1_0s",
+      "command_index": 1,
+      "delay_seconds": 0,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9154,
+          "y": -2.6712,
+          "toward": 109.0025,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9154,
+            "y": -2.6712,
+            "toward": 109.0025,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 109,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -60,
+          "wifi_rssi": -54,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_1_sample_2_5s",
+      "command_index": 1,
+      "delay_seconds": 5,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9191,
+          "y": -2.6687,
+          "toward": 109.0025,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9191,
+            "y": -2.6687,
+            "toward": 109.0025,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 109,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -64,
+          "wifi_rssi": -56,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_1_sample_3_10s",
+      "command_index": 1,
+      "delay_seconds": 10,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9191,
+          "y": -2.6687,
+          "toward": 109.0025,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9191,
+            "y": -2.6687,
+            "toward": 109.0025,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 109,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -64,
+          "wifi_rssi": -56,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_1_sample_4_20s",
+      "command_index": 1,
+      "delay_seconds": 20,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9191,
+          "y": -2.6687,
+          "toward": 109.0025,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9191,
+            "y": -2.6687,
+            "toward": 109.0025,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 109,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -64,
+          "wifi_rssi": -56,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_1_sample_5_30s",
+      "command_index": 1,
+      "delay_seconds": 30,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9191,
+          "y": -2.6687,
+          "toward": 109.0025,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9191,
+            "y": -2.6687,
+            "toward": 109.0025,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 109,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -64,
+          "wifi_rssi": -56,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_1_sample_6_45s",
+      "command_index": 1,
+      "delay_seconds": 45,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9191,
+          "y": -2.6687,
+          "toward": 109.0025,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9191,
+            "y": -2.6687,
+            "toward": 109.0025,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 109,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -64,
+          "wifi_rssi": -56,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_1_sample_7_60s",
+      "command_index": 1,
+      "delay_seconds": 60,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9191,
+          "y": -2.6687,
+          "toward": 109.0025,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9191,
+            "y": -2.6687,
+            "toward": 109.0025,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 109,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -64,
+          "wifi_rssi": -56,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_2_sample_1_0s",
+      "command_index": 2,
+      "delay_seconds": 0,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.942,
+          "y": -2.7041,
+          "toward": 50.2717,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.942,
+            "y": -2.7041,
+            "toward": 50.2717,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 50,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -66,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_2_sample_2_5s",
+      "command_index": 2,
+      "delay_seconds": 5,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9438,
+          "y": -2.7016,
+          "toward": 50.2717,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9438,
+            "y": -2.7016,
+            "toward": 50.2717,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 50,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -62,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_2_sample_3_10s",
+      "command_index": 2,
+      "delay_seconds": 10,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9438,
+          "y": -2.7016,
+          "toward": 50.2717,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9438,
+            "y": -2.7016,
+            "toward": 50.2717,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 50,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -62,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_2_sample_4_20s",
+      "command_index": 2,
+      "delay_seconds": 20,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9438,
+          "y": -2.7016,
+          "toward": 50.2717,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9438,
+            "y": -2.7016,
+            "toward": 50.2717,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 50,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -62,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_2_sample_5_30s",
+      "command_index": 2,
+      "delay_seconds": 30,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9438,
+          "y": -2.7016,
+          "toward": 50.2717,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9438,
+            "y": -2.7016,
+            "toward": 50.2717,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 50,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -62,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_2_sample_6_45s",
+      "command_index": 2,
+      "delay_seconds": 45,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9438,
+          "y": -2.7016,
+          "toward": 50.2717,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9438,
+            "y": -2.7016,
+            "toward": 50.2717,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 50,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -62,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_2_sample_7_60s",
+      "command_index": 2,
+      "delay_seconds": 60,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9438,
+          "y": -2.7016,
+          "toward": 50.2717,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9438,
+            "y": -2.7016,
+            "toward": 50.2717,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 50,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -62,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_3_sample_1_0s",
+      "command_index": 3,
+      "delay_seconds": 0,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9391,
+          "y": -2.6468,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9391,
+            "y": -2.6468,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -66,
+          "wifi_rssi": -55,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_3_sample_2_5s",
+      "command_index": 3,
+      "delay_seconds": 5,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9395,
+          "y": -2.6468,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9395,
+            "y": -2.6468,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -60,
+          "wifi_rssi": -55,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_3_sample_3_10s",
+      "command_index": 3,
+      "delay_seconds": 10,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9395,
+          "y": -2.6468,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9395,
+            "y": -2.6468,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -60,
+          "wifi_rssi": -55,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_3_sample_4_20s",
+      "command_index": 3,
+      "delay_seconds": 20,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9395,
+          "y": -2.6468,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9395,
+            "y": -2.6468,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -60,
+          "wifi_rssi": -55,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_3_sample_5_30s",
+      "command_index": 3,
+      "delay_seconds": 30,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9395,
+          "y": -2.6468,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9395,
+            "y": -2.6468,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -60,
+          "wifi_rssi": -55,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_3_sample_6_45s",
+      "command_index": 3,
+      "delay_seconds": 45,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9395,
+          "y": -2.6468,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9395,
+            "y": -2.6468,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -60,
+          "wifi_rssi": -55,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "command_3_sample_7_60s",
+      "command_index": 3,
+      "delay_seconds": 60,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 4.9395,
+          "y": -2.6468,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 4.9395,
+            "y": -2.6468,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -60,
+          "wifi_rssi": -55,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_1_sample_1_0s",
+      "command_index": 1,
+      "delay_seconds": 0,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.4693,
+          "y": -2.6383,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.4693,
+            "y": -2.6383,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -58,
+          "wifi_rssi": -59,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_1_sample_2_5s",
+      "command_index": 1,
+      "delay_seconds": 5,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.4693,
+          "y": -2.6383,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.4693,
+            "y": -2.6383,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_1_sample_3_10s",
+      "command_index": 1,
+      "delay_seconds": 10,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.4693,
+          "y": -2.6383,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.4693,
+            "y": -2.6383,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_1_sample_4_20s",
+      "command_index": 1,
+      "delay_seconds": 20,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.4693,
+          "y": -2.6383,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.4693,
+            "y": -2.6383,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_1_sample_5_30s",
+      "command_index": 1,
+      "delay_seconds": 30,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.4693,
+          "y": -2.6383,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.4693,
+            "y": -2.6383,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_1_sample_6_45s",
+      "command_index": 1,
+      "delay_seconds": 45,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.4693,
+          "y": -2.6383,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.4693,
+            "y": -2.6383,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_1_sample_7_60s",
+      "command_index": 1,
+      "delay_seconds": 60,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.4693,
+          "y": -2.6383,
+          "toward": 90.3537,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.4693,
+            "y": -2.6383,
+            "toward": 90.3537,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 90,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_2_sample_1_0s",
+      "command_index": 2,
+      "delay_seconds": 0,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.7675,
+          "y": -2.6369,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.7675,
+            "y": -2.6369,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -58,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_2_sample_2_5s",
+      "command_index": 2,
+      "delay_seconds": 5,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.7673,
+          "y": -2.6361,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.7673,
+            "y": -2.6361,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_2_sample_3_10s",
+      "command_index": 2,
+      "delay_seconds": 10,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.7673,
+          "y": -2.6361,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.7673,
+            "y": -2.6361,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_2_sample_4_20s",
+      "command_index": 2,
+      "delay_seconds": 20,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.7673,
+          "y": -2.6361,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.7673,
+            "y": -2.6361,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_2_sample_5_30s",
+      "command_index": 2,
+      "delay_seconds": 30,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.7673,
+          "y": -2.6361,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.7673,
+            "y": -2.6361,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_2_sample_6_45s",
+      "command_index": 2,
+      "delay_seconds": 45,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.7673,
+          "y": -2.6361,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.7673,
+            "y": -2.6361,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_2_sample_7_60s",
+      "command_index": 2,
+      "delay_seconds": 60,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.7673,
+          "y": -2.6361,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.7673,
+            "y": -2.6361,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -56,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_3_sample_1_0s",
+      "command_index": 3,
+      "delay_seconds": 0,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.8041,
+          "y": -2.6358,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.8041,
+            "y": -2.6358,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -58,
+          "wifi_rssi": -57,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_3_sample_2_5s",
+      "command_index": 3,
+      "delay_seconds": 5,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.8041,
+          "y": -2.6358,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.8041,
+            "y": -2.6358,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -58,
+          "wifi_rssi": -58,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_3_sample_3_10s",
+      "command_index": 3,
+      "delay_seconds": 10,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.8041,
+          "y": -2.6358,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.8041,
+            "y": -2.6358,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -58,
+          "wifi_rssi": -58,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_3_sample_4_20s",
+      "command_index": 3,
+      "delay_seconds": 20,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.8041,
+          "y": -2.6358,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.8041,
+            "y": -2.6358,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -58,
+          "wifi_rssi": -58,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_3_sample_5_30s",
+      "command_index": 3,
+      "delay_seconds": 30,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.8041,
+          "y": -2.6358,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.8041,
+            "y": -2.6358,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -58,
+          "wifi_rssi": -58,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_3_sample_6_45s",
+      "command_index": 3,
+      "delay_seconds": 45,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.8041,
+          "y": -2.6358,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.8041,
+            "y": -2.6358,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -58,
+          "wifi_rssi": -58,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    },
+    {
+      "label": "linear_3_sample_7_60s",
+      "command_index": 3,
+      "delay_seconds": 60,
+      "telemetry": {
+        "online": true,
+        "work_mode": 11,
+        "work_mode_label": "MODE_READY",
+        "charge_state": 0,
+        "charge_state_label": "not_charging",
+        "position": {
+          "x": 5.8041,
+          "y": -2.6358,
+          "toward": 89.1396,
+          "source": "report_data.locations[0]",
+          "pos_level": 1,
+          "pos_level_label": "SINGLE",
+          "rtk_status": 4,
+          "rtk_status_label": "Fix",
+          "pos_type": 1,
+          "pos_type_label": "AREA_INSIDE",
+          "zone_hash": "1343645155037768237",
+          "map_bol_hash": "3192426378327374167",
+          "area_name": "Backyard Right",
+          "valid_for_motion": true
+        },
+        "position_candidates": [
+          {
+            "source": "mowing_state",
+            "x": 0,
+            "y": 0,
+            "toward": 0,
+            "pos_level": 0,
+            "pos_level_label": "FIX",
+            "rtk_status": 0,
+            "rtk_status_label": "None",
+            "pos_type": 0,
+            "pos_type_label": "AREA_OUT",
+            "zone_hash": 0,
+            "area_name": null,
+            "stale_zero_area_out": true,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.locations[0]",
+            "x": 5.8041,
+            "y": -2.6358,
+            "toward": 89.1396,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "location_metadata",
+            "x": null,
+            "y": null,
+            "toward": 89,
+            "pos_level": null,
+            "pos_level_label": null,
+            "rtk_status": null,
+            "rtk_status_label": null,
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "area_name": "Backyard Right",
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          },
+          {
+            "source": "report_data.rtk",
+            "x": null,
+            "y": null,
+            "toward": null,
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": null,
+            "pos_type_label": null,
+            "zone_hash": null,
+            "area_name": null,
+            "stale_zero_area_out": false,
+            "valid_for_motion": false
+          }
+        ],
+        "blade": {
+          "reported_state": 0,
+          "reported_state_label": "OFF",
+          "knife_status": null,
+          "current_cutter_mode": 0,
+          "current_cutter_rpm": 0
+        },
+        "transport": {
+          "ble_rssi": -58,
+          "wifi_rssi": -58,
+          "wifi_connect_status": null,
+          "iot_connect_status": null,
+          "connection_label": "WIFI/BLE"
+        }
+      }
+    }
+  ],
+  "phases": [
+    {
+      "name": "turn_to_target_heading",
+      "turn_mode": "night",
+      "passed": true,
+      "result": {
+        "service": "raw_pymammotion_turn_to_heading",
+        "mode": "real_raw_turn_to_heading",
+        "dry_run": false,
+        "would_send": true,
+        "real_execution_scope": "turn_to_heading_only",
+        "path_execution_allowed": false,
+        "target_heading_degrees": 86.95748070304057,
+        "heading_tolerance_degrees": 8,
+        "angular_speed_fast": 500,
+        "angular_speed_slow": 500,
+        "slow_turn_threshold_degrees": 8,
+        "max_commands": 4,
+        "min_heading_change_degrees": 0.5,
+        "max_translation_distance": 0.3,
+        "prefer_ble": true,
+        "transport_preference": "ble_preferred",
+        "motion_refresh_interval_ms": 200,
+        "sample_delays": [
+          0,
+          5,
+          10,
+          20,
+          30,
+          45,
+          60
+        ],
+        "confirm_blades_off": true,
+        "confirm_clear_area": true,
+        "initial_command_selection": {
+          "command": "send_movement",
+          "linear_speed": 0,
+          "angular_speed": -500,
+          "direction": "negative_heading",
+          "positive_heading_uses_positive_angular_speed": true,
+          "negative_heading_uses_negative_angular_speed": true,
+          "heading_error_degrees": -86.98001929695943,
+          "absolute_heading_error_degrees": 86.98001929695943,
+          "speed_tier": "fast",
+          "slow_turn_threshold_degrees": 8
+        },
+        "initial_heading_status": {
+          "complete": false,
+          "current_heading_degrees": 173.9375,
+          "target_heading_degrees": 86.95748070304057,
+          "heading_error_degrees": -86.98001929695943,
+          "absolute_heading_error_degrees": 86.98001929695943,
+          "heading_tolerance_degrees": 8,
+          "reason": "target_heading_remaining"
+        },
+        "heading_status": {
+          "complete": true,
+          "current_heading_degrees": 90.3537,
+          "target_heading_degrees": 86.95748070304057,
+          "heading_error_degrees": -3.39621929695943,
+          "absolute_heading_error_degrees": 3.39621929695943,
+          "heading_tolerance_degrees": 8,
+          "reason": "target_heading_reached"
+        },
+        "initial_telemetry": {
+          "online": true,
+          "work_mode": 11,
+          "work_mode_label": "MODE_READY",
+          "charge_state": 0,
+          "charge_state_label": "not_charging",
+          "position": {
+            "x": 4.9541,
+            "y": -2.6429,
+            "toward": 173.9375,
+            "source": "report_data.locations[0]",
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "map_bol_hash": "3192426378327374167",
+            "area_name": "Backyard Right",
+            "valid_for_motion": true
+          },
+          "position_candidates": [
+            {
+              "source": "mowing_state",
+              "x": 0,
+              "y": 0,
+              "toward": 0,
+              "pos_level": 0,
+              "pos_level_label": "FIX",
+              "rtk_status": 0,
+              "rtk_status_label": "None",
+              "pos_type": 0,
+              "pos_type_label": "AREA_OUT",
+              "zone_hash": 0,
+              "area_name": null,
+              "stale_zero_area_out": true,
+              "valid_for_motion": false
+            },
+            {
+              "source": "report_data.locations[0]",
+              "x": 4.9541,
+              "y": -2.6429,
+              "toward": 173.9375,
+              "pos_level": null,
+              "pos_level_label": null,
+              "rtk_status": null,
+              "rtk_status_label": null,
+              "pos_type": 1,
+              "pos_type_label": "AREA_INSIDE",
+              "zone_hash": null,
+              "area_name": null,
+              "stale_zero_area_out": false,
+              "valid_for_motion": false
+            },
+            {
+              "source": "location_metadata",
+              "x": null,
+              "y": null,
+              "toward": 173,
+              "pos_level": null,
+              "pos_level_label": null,
+              "rtk_status": null,
+              "rtk_status_label": null,
+              "pos_type": 1,
+              "pos_type_label": "AREA_INSIDE",
+              "zone_hash": "1343645155037768237",
+              "area_name": "Backyard Right",
+              "stale_zero_area_out": false,
+              "valid_for_motion": false
+            },
+            {
+              "source": "report_data.rtk",
+              "x": null,
+              "y": null,
+              "toward": null,
+              "pos_level": 1,
+              "pos_level_label": "SINGLE",
+              "rtk_status": 4,
+              "rtk_status_label": "Fix",
+              "pos_type": null,
+              "pos_type_label": null,
+              "zone_hash": null,
+              "area_name": null,
+              "stale_zero_area_out": false,
+              "valid_for_motion": false
+            }
+          ],
+          "blade": {
+            "reported_state": 0,
+            "reported_state_label": "OFF",
+            "knife_status": null,
+            "current_cutter_mode": 0,
+            "current_cutter_rpm": 0
+          },
+          "transport": {
+            "ble_rssi": -64,
+            "wifi_rssi": -55,
+            "wifi_connect_status": null,
+            "iot_connect_status": null,
+            "connection_label": "WIFI/BLE"
+          }
+        },
+        "final_telemetry": {
+          "online": true,
+          "work_mode": 11,
+          "work_mode_label": "MODE_READY",
+          "charge_state": 0,
+          "charge_state_label": "not_charging",
+          "position": {
+            "x": 4.9395,
+            "y": -2.6468,
+            "toward": 90.3537,
+            "source": "report_data.locations[0]",
+            "pos_level": 1,
+            "pos_level_label": "SINGLE",
+            "rtk_status": 4,
+            "rtk_status_label": "Fix",
+            "pos_type": 1,
+            "pos_type_label": "AREA_INSIDE",
+            "zone_hash": "1343645155037768237",
+            "map_bol_hash": "3192426378327374167",
+            "area_name": "Backyard Right",
+            "valid_for_motion": true
+          },
+          "position_candidates": [
+            {
+              "source": "mowing_state",
+              "x": 0,
+              "y": 0,
+              "toward": 0,
+              "pos_level": 0,
+              "pos_level_label": "FIX",
+              "rtk_status": 0,
+              "rtk_status_label": "None",
+              "pos_type": 0,
+              "pos_type_label": "AREA_OUT",
+              "zone_hash": 0,
+              "area_name": null,
+              "stale_zero_area_out": true,
+              "valid_for_motion": false
+            },
+            {
+              "source": "report_data.locations[0]",
+              "x": 4.9395,
+              "y": -2.6468,
+              "toward": 90.3537,
+              "pos_level": null,
+              "pos_level_label": null,
+              "rtk_status": null,
+              "rtk_status_label": null,
+              "pos_type": 1,
+              "pos_type_label": "AREA_INSIDE",
+              "zone_hash": null,
+              "area_name": null,
+              "stale_zero_area_out": false,
+              "valid_for_motion": false
+            },
+            {
+              "source": "location_metadata",
+              "x": null,
+              "y": null,
+              "toward": 90,
+              "pos_level": null,
+              "pos_level_label": null,
+              "rtk_status": null,
+              "rtk_status_label": null,
+              "pos_type": 1,
+              "pos_type_label": "AREA_INSIDE",
+              "zone_hash": "1343645155037768237",
+              "area_name": "Backyard Right",
+              "stale_zero_area_out": false,
+              "valid_for_motion": false
+            },
+            {
+              "source": "report_data.rtk",
+              "x": null,
+              "y": null,
+              "toward": null,
+              "pos_level": 1,
+              "pos_level_label": "SINGLE",
+              "rtk_status": 4,
+              "rtk_status_label": "Fix",
+              "pos_type": null,
+              "pos_type_label": null,
+              "zone_hash": null,
+              "area_name": null,
+              "stale_zero_area_out": false,
+              "valid_for_motion": false
+            }
+          ],
+          "blade": {
+            "reported_state": 0,
+            "reported_state_label": "OFF",
+            "knife_status": null,
+            "current_cutter_mode": 0,
+            "current_cutter_rpm": 0
+          },
+          "transport": {
+            "ble_rssi": -60,
+            "wifi_rssi": -55,
+            "wifi_connect_status": null,
+            "iot_connect_status": null,
+            "connection_label": "WIFI/BLE"
+          }
+        },
+        "runtime_safety": {
+          "allowed_for_manual_motion": true,
+          "blockers": [],
+          "blade_safe_for_motion": true,
+          "active_mowing_detected": false,
+          "active_route_detected": false,
+          "active_route_status": {
+            "route_present": false,
+            "progress_present": false,
+            "progress_is_active": false,
+            "blocks_motion": false,
+            "reason": "no_route",
+            "ha_state": "paused",
+            "work_mode_label": "MODE_READY"
+          },
+          "position_valid_for_motion": true,
+          "rtk_report_age_seconds": null,
+          "rtk_report_quiet_threshold_seconds": 1800,
+          "rtk_report_quiet": false,
+          "rtk_status_label": "Fix",
+          "rtk_degraded": false,
+          "rtk_degraded_override": false
+        },
+        "safety_gates": [
+          {
+            "name": "stop_primitive_available",
+            "passed": true,
+            "detail": "Coordinator must expose async_stop_manual_motion()."
+          },
+          {
+            "name": "ble_transport_required",
+            "passed": true,
+            "detail": "Real closed-loop motion requires the BLE transport for responsive telemetry; cloud/Wi-Fi lag is unsafe for guarded path execution. BLE must also report itself usable -- being selected for routing does not mean a command can be delivered."
+          },
+          {
+            "name": "ble_link_live",
+            "passed": true,
+            "detail": "Real motion requires a conservative BLE preflight -- a live client, an open dispatch gate, an empty command queue, and a recent outbound attempt. 'Usable' only means BLE is eligible for routing; it stays True while the command queue is gated and commands (including the mandatory stop that bounds a pulse) accumulate undelivered. The send path separately waits for confirmed queue start and GATT-write completion. See docs/pymammotion-ble-slot-leak-bug.md.",
+            "diagnostics": {
+              "live": true,
+              "reason": null,
+              "is_connected": true,
+              "is_usable": true,
+              "cooldown_active": false,
+              "cooldown_remaining_seconds": 0,
+              "last_send_age_seconds": 1.8,
+              "queue_depth": 0,
+              "queue_dispatch_paused": false,
+              "saga_active": false,
+              "stall_threshold_seconds": 15,
+              "queue_depth_limit": 0
+            }
+          },
+          {
+            "name": "operator_confirmed_blades_off",
+            "passed": true,
+            "detail": "Real pulse requires confirm_blades_off=true."
+          },
+          {
+            "name": "operator_confirmed_clear_area",
+            "passed": true,
+            "detail": "Real pulse requires confirm_clear_area=true."
+          },
+          {
+            "name": "mower_reports_blades_off",
+            "passed": true,
+            "detail": "Real pulse requires blade state off and cutter RPM zero/unknown."
+          },
+          {
+            "name": "mower_ready",
+            "passed": true,
+            "detail": "Real pulse requires the mower to be ready/paused, not mowing or charging."
+          },
+          {
+            "name": "not_docked_or_charging",
+            "passed": true,
+            "detail": "Real pulse requires the mower to be off the dock and not charging."
+          },
+          {
+            "name": "live_map_position_available",
+            "passed": true,
+            "detail": "Real pulse requires live map-local mower position."
+          },
+          {
+            "name": "position_area_inside",
+            "passed": true,
+            "detail": "Real pulse requires AREA_INSIDE, TURN_AREA_INSIDE, or CHANNEL_AREA_OVERLAP and a nonzero known zone hash."
+          },
+          {
+            "name": "map_position_nonzero",
+            "passed": true,
+            "detail": "Real pulse requires nonzero map-local x/y coordinates."
+          }
+        ],
+        "blockers": [],
+        "commands_sent": 3,
+        "command_results": [
+          {
+            "index": 1,
+            "attempted": true,
+            "ok": true,
+            "ack": null,
+            "error": null,
+            "duration_ms": 422.162,
+            "command": "send_movement",
+            "prefer_ble": true,
+            "kwargs": {
+              "linear_speed": 0,
+              "angular_speed": -500
+            },
+            "selection": {
+              "command": "send_movement",
+              "linear_speed": 0,
+              "angular_speed": -500,
+              "direction": "negative_heading",
+              "positive_heading_uses_positive_angular_speed": true,
+              "negative_heading_uses_negative_angular_speed": true,
+              "heading_error_degrees": -86.98001929695943,
+              "absolute_heading_error_degrees": 86.98001929695943,
+              "speed_tier": "fast",
+              "slow_turn_threshold_degrees": 8
+            },
+            "motion_refresh": {
+              "refresh_enabled": true,
+              "refresh_interval_ms": 200,
+              "refresh_commands_sent": 5,
+              "refresh_command_limit": null,
+              "refresh_write_durations_ms": [
+                187.29,
+                230.497,
+                208.532,
+                568.404,
+                305.598
+              ],
+              "max_refresh_commands": 7,
+              "elapsed_ms": 1717.278
+            },
+            "stop_result": {
+              "attempted": true,
+              "ok": true,
+              "error": null,
+              "coordinator_method": "async_stop_manual_motion",
+              "use_wifi": false,
+              "transport_preference": "ble_preferred",
+              "ack": {
+                "movement_ok": true
+              },
+              "duration_ms": 129.937
+            },
+            "post_command_feedback_refresh": {
+              "method": "request_reports_count_5",
+              "settle_seconds": 2,
+              "ok": true,
+              "error": null,
+              "duration_ms": 2001.463
+            }
+          },
+          {
+            "index": 2,
+            "attempted": true,
+            "ok": true,
+            "ack": null,
+            "error": null,
+            "duration_ms": 298.598,
+            "command": "send_movement",
+            "prefer_ble": true,
+            "kwargs": {
+              "linear_speed": 0,
+              "angular_speed": -500
+            },
+            "selection": {
+              "command": "send_movement",
+              "linear_speed": 0,
+              "angular_speed": -500,
+              "direction": "negative_heading",
+              "positive_heading_uses_positive_angular_speed": true,
+              "negative_heading_uses_negative_angular_speed": true,
+              "heading_error_degrees": -22.04501929695948,
+              "absolute_heading_error_degrees": 22.04501929695948,
+              "speed_tier": "fast",
+              "slow_turn_threshold_degrees": 8
+            },
+            "motion_refresh": {
+              "refresh_enabled": true,
+              "refresh_interval_ms": 200,
+              "refresh_commands_sent": 4,
+              "refresh_command_limit": null,
+              "refresh_write_durations_ms": [
+                292.575,
+                310.493,
+                416.159,
+                302.53
+              ],
+              "max_refresh_commands": 7,
+              "elapsed_ms": 1611.029
+            },
+            "stop_result": {
+              "attempted": true,
+              "ok": true,
+              "error": null,
+              "coordinator_method": "async_stop_manual_motion",
+              "use_wifi": false,
+              "transport_preference": "ble_preferred",
+              "ack": {
+                "movement_ok": true
+              },
+              "duration_ms": 136.399
+            },
+            "post_command_feedback_refresh": {
+              "method": "request_reports_count_5",
+              "settle_seconds": 2,
+              "ok": true,
+              "error": null,
+              "duration_ms": 2060.775
+            }
+          },
+          {
+            "index": 3,
+            "attempted": true,
+            "ok": true,
+            "ack": null,
+            "error": null,
+            "duration_ms": 68.981,
+            "command": "send_movement",
+            "prefer_ble": true,
+            "kwargs": {
+              "linear_speed": 0,
+              "angular_speed": 500
+            },
+            "selection": {
+              "command": "send_movement",
+              "linear_speed": 0,
+              "angular_speed": 500,
+              "direction": "positive_heading",
+              "positive_heading_uses_positive_angular_speed": true,
+              "negative_heading_uses_negative_angular_speed": true,
+              "heading_error_degrees": 36.685780703040564,
+              "absolute_heading_error_degrees": 36.685780703040564,
+              "speed_tier": "fast",
+              "slow_turn_threshold_degrees": 8
+            },
+            "motion_refresh": {
+              "refresh_enabled": true,
+              "refresh_interval_ms": 200,
+              "refresh_commands_sent": 4,
+              "refresh_command_limit": null,
+              "refresh_write_durations_ms": [
+                219.399,
+                737.895,
+                244.52,
+                181.715
+              ],
+              "max_refresh_commands": 7,
+              "elapsed_ms": 1584.984
+            },
+            "stop_result": {
+              "attempted": true,
+              "ok": true,
+              "error": null,
+              "coordinator_method": "async_stop_manual_motion",
+              "use_wifi": false,
+              "transport_preference": "ble_preferred",
+              "ack": {
+                "movement_ok": true
+              },
+              "duration_ms": 176.495
+            },
+            "post_command_feedback_refresh": {
+              "method": "request_reports_count_5",
+              "settle_seconds": 2,
+              "ok": true,
+              "error": null,
+              "duration_ms": 2000.838
+            }
+          }
+        ],
+        "samples": [
+          {
+            "label": "initial",
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9541,
+                "y": -2.6429,
+                "toward": 173.9375,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9541,
+                  "y": -2.6429,
+                  "toward": 173.9375,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 173,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -64,
+                "wifi_rssi": -55,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_1_sample_1_0s",
+            "command_index": 1,
+            "delay_seconds": 0,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9154,
+                "y": -2.6712,
+                "toward": 109.0025,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9154,
+                  "y": -2.6712,
+                  "toward": 109.0025,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 109,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -60,
+                "wifi_rssi": -54,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_1_sample_2_5s",
+            "command_index": 1,
+            "delay_seconds": 5,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9191,
+                "y": -2.6687,
+                "toward": 109.0025,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9191,
+                  "y": -2.6687,
+                  "toward": 109.0025,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 109,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -64,
+                "wifi_rssi": -56,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_1_sample_3_10s",
+            "command_index": 1,
+            "delay_seconds": 10,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9191,
+                "y": -2.6687,
+                "toward": 109.0025,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9191,
+                  "y": -2.6687,
+                  "toward": 109.0025,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 109,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -64,
+                "wifi_rssi": -56,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_1_sample_4_20s",
+            "command_index": 1,
+            "delay_seconds": 20,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9191,
+                "y": -2.6687,
+                "toward": 109.0025,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9191,
+                  "y": -2.6687,
+                  "toward": 109.0025,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 109,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -64,
+                "wifi_rssi": -56,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_1_sample_5_30s",
+            "command_index": 1,
+            "delay_seconds": 30,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9191,
+                "y": -2.6687,
+                "toward": 109.0025,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9191,
+                  "y": -2.6687,
+                  "toward": 109.0025,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 109,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -64,
+                "wifi_rssi": -56,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_1_sample_6_45s",
+            "command_index": 1,
+            "delay_seconds": 45,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9191,
+                "y": -2.6687,
+                "toward": 109.0025,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9191,
+                  "y": -2.6687,
+                  "toward": 109.0025,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 109,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -64,
+                "wifi_rssi": -56,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_1_sample_7_60s",
+            "command_index": 1,
+            "delay_seconds": 60,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9191,
+                "y": -2.6687,
+                "toward": 109.0025,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9191,
+                  "y": -2.6687,
+                  "toward": 109.0025,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 109,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -64,
+                "wifi_rssi": -56,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_2_sample_1_0s",
+            "command_index": 2,
+            "delay_seconds": 0,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.942,
+                "y": -2.7041,
+                "toward": 50.2717,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.942,
+                  "y": -2.7041,
+                  "toward": 50.2717,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 50,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -66,
+                "wifi_rssi": -57,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_2_sample_2_5s",
+            "command_index": 2,
+            "delay_seconds": 5,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9438,
+                "y": -2.7016,
+                "toward": 50.2717,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9438,
+                  "y": -2.7016,
+                  "toward": 50.2717,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 50,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -62,
+                "wifi_rssi": -57,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_2_sample_3_10s",
+            "command_index": 2,
+            "delay_seconds": 10,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9438,
+                "y": -2.7016,
+                "toward": 50.2717,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9438,
+                  "y": -2.7016,
+                  "toward": 50.2717,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 50,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -62,
+                "wifi_rssi": -57,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_2_sample_4_20s",
+            "command_index": 2,
+            "delay_seconds": 20,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9438,
+                "y": -2.7016,
+                "toward": 50.2717,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9438,
+                  "y": -2.7016,
+                  "toward": 50.2717,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 50,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -62,
+                "wifi_rssi": -57,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_2_sample_5_30s",
+            "command_index": 2,
+            "delay_seconds": 30,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9438,
+                "y": -2.7016,
+                "toward": 50.2717,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9438,
+                  "y": -2.7016,
+                  "toward": 50.2717,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 50,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -62,
+                "wifi_rssi": -57,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_2_sample_6_45s",
+            "command_index": 2,
+            "delay_seconds": 45,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9438,
+                "y": -2.7016,
+                "toward": 50.2717,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9438,
+                  "y": -2.7016,
+                  "toward": 50.2717,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 50,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -62,
+                "wifi_rssi": -57,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_2_sample_7_60s",
+            "command_index": 2,
+            "delay_seconds": 60,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9438,
+                "y": -2.7016,
+                "toward": 50.2717,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9438,
+                  "y": -2.7016,
+                  "toward": 50.2717,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 50,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -62,
+                "wifi_rssi": -57,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_3_sample_1_0s",
+            "command_index": 3,
+            "delay_seconds": 0,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9391,
+                "y": -2.6468,
+                "toward": 90.3537,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9391,
+                  "y": -2.6468,
+                  "toward": 90.3537,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 90,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -66,
+                "wifi_rssi": -55,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_3_sample_2_5s",
+            "command_index": 3,
+            "delay_seconds": 5,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9395,
+                "y": -2.6468,
+                "toward": 90.3537,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9395,
+                  "y": -2.6468,
+                  "toward": 90.3537,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 90,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -60,
+                "wifi_rssi": -55,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_3_sample_3_10s",
+            "command_index": 3,
+            "delay_seconds": 10,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9395,
+                "y": -2.6468,
+                "toward": 90.3537,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9395,
+                  "y": -2.6468,
+                  "toward": 90.3537,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 90,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -60,
+                "wifi_rssi": -55,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_3_sample_4_20s",
+            "command_index": 3,
+            "delay_seconds": 20,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9395,
+                "y": -2.6468,
+                "toward": 90.3537,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9395,
+                  "y": -2.6468,
+                  "toward": 90.3537,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 90,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -60,
+                "wifi_rssi": -55,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_3_sample_5_30s",
+            "command_index": 3,
+            "delay_seconds": 30,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9395,
+                "y": -2.6468,
+                "toward": 90.3537,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9395,
+                  "y": -2.6468,
+                  "toward": 90.3537,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 90,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -60,
+                "wifi_rssi": -55,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_3_sample_6_45s",
+            "command_index": 3,
+            "delay_seconds": 45,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9395,
+                "y": -2.6468,
+                "toward": 90.3537,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9395,
+                  "y": -2.6468,
+                  "toward": 90.3537,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 90,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -60,
+                "wifi_rssi": -55,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          },
+          {
+            "label": "command_3_sample_7_60s",
+            "command_index": 3,
+            "delay_seconds": 60,
+            "telemetry": {
+              "online": true,
+              "work_mode": 11,
+              "work_mode_label": "MODE_READY",
+              "charge_state": 0,
+              "charge_state_label": "not_charging",
+              "position": {
+                "x": 4.9395,
+                "y": -2.6468,
+                "toward": 90.3537,
+                "source": "report_data.locations[0]",
+                "pos_level": 1,
+                "pos_level_label": "SINGLE",
+                "rtk_status": 4,
+                "rtk_status_label": "Fix",
+                "pos_type": 1,
+                "pos_type_label": "AREA_INSIDE",
+                "zone_hash": "1343645155037768237",
+                "map_bol_hash": "3192426378327374167",
+                "area_name": "Backyard Right",
+                "valid_for_motion": true
+              },
+              "position_candidates": [
+                {
+                  "source": "mowing_state",
+                  "x": 0,
+                  "y": 0,
+                  "toward": 0,
+                  "pos_level": 0,
+                  "pos_level_label": "FIX",
+                  "rtk_status": 0,
+                  "rtk_status_label": "None",
+                  "pos_type": 0,
+                  "pos_type_label": "AREA_OUT",
+                  "zone_hash": 0,
+                  "area_name": null,
+                  "stale_zero_area_out": true,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.locations[0]",
+                  "x": 4.9395,
+                  "y": -2.6468,
+                  "toward": 90.3537,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "location_metadata",
+                  "x": null,
+                  "y": null,
+                  "toward": 90,
+                  "pos_level": null,
+                  "pos_level_label": null,
+                  "rtk_status": null,
+                  "rtk_status_label": null,
+                  "pos_type": 1,
+                  "pos_type_label": "AREA_INSIDE",
+                  "zone_hash": "1343645155037768237",
+                  "area_name": "Backyard Right",
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                },
+                {
+                  "source": "report_data.rtk",
+                  "x": null,
+                  "y": null,
+                  "toward": null,
+                  "pos_level": 1,
+                  "pos_level_label": "SINGLE",
+                  "rtk_status": 4,
+                  "rtk_status_label": "Fix",
+                  "pos_type": null,
+                  "pos_type_label": null,
+                  "zone_hash": null,
+                  "area_name": null,
+                  "stale_zero_area_out": false,
+                  "valid_for_motion": false
+                }
+              ],
+              "blade": {
+                "reported_state": 0,
+                "reported_state_label": "OFF",
+                "knife_status": null,
+                "current_cutter_mode": 0,
+                "current_cutter_rpm": 0
+              },
+              "transport": {
+                "ble_rssi": -60,
+                "wifi_rssi": -55,
+                "wifi_connect_status": null,
+                "iot_connect_status": null,
+                "connection_label": "WIFI/BLE"
+              }
+            }
+          }
+        ],
+        "heading_diagnostics": [
+          {
+            "status": "heading_progress",
+            "passed": true,
+            "direction": "negative_heading",
+            "heading_change_degrees": -64.935,
+            "target_direction_progress_degrees": 64.935,
+            "measured_delta": {
+              "distance": 0.043481490314845474,
+              "dx": -0.03500000000000014,
+              "dy": -0.025799999999999823,
+              "heading_change_degrees": -64.935
+            },
+            "min_heading_change_degrees": 0.5,
+            "max_translation_distance": 0.3,
+            "excessive_translation": false,
+            "command_index": 1
+          },
+          {
+            "status": "heading_progress",
+            "passed": true,
+            "direction": "negative_heading",
+            "heading_change_degrees": -58.73079999999999,
+            "target_direction_progress_degrees": 58.73079999999999,
+            "measured_delta": {
+              "distance": 0.04114000486144864,
+              "dx": 0.024700000000000166,
+              "dy": -0.03290000000000015,
+              "heading_change_degrees": -58.73079999999999
+            },
+            "min_heading_change_degrees": 0.5,
+            "max_translation_distance": 0.3,
+            "excessive_translation": false,
+            "command_index": 2
+          },
+          {
+            "status": "heading_progress",
+            "passed": true,
+            "direction": "positive_heading",
+            "heading_change_degrees": 40.081999999999994,
+            "target_direction_progress_degrees": 40.081999999999994,
+            "measured_delta": {
+              "distance": 0.05496844549375601,
+              "dx": -0.004300000000000637,
+              "dy": 0.05480000000000018,
+              "heading_change_degrees": 40.081999999999994
+            },
+            "min_heading_change_degrees": 0.5,
+            "max_translation_distance": 0.3,
+            "excessive_translation": false,
+            "command_index": 3
+          }
+        ],
+        "stop_reason": "target_heading_reached"
+      }
+    }
+  ],
+  "progress_diagnostics": [
+    {
+      "status": "path_progress",
+      "passed": true,
+      "action": "forward",
+      "path_progress_distance": 0.5293687284446582,
+      "expected_target_heading_degrees": 3.4070760191693807,
+      "movement_vector_heading_degrees": 0.9191626009473453,
+      "heading_progress": true,
+      "min_progress_distance": 0.06,
+      "min_heading_change_degrees": 0,
+      "command_index": 1,
+      "measured_delta": {
+        "distance": 0.5298681817206992,
+        "dx": 0.5297999999999998,
+        "dy": 0.00849999999999973,
+        "heading_change_degrees": 0
+      }
+    },
+    {
+      "status": "path_progress",
+      "passed": true,
+      "action": "forward",
+      "path_progress_distance": 0.2944723467743068,
+      "expected_target_heading_degrees": 9.257769838750107,
+      "movement_vector_heading_degrees": 0.42298129193369505,
+      "heading_progress": true,
+      "min_progress_distance": 0.06,
+      "min_heading_change_degrees": 0,
+      "command_index": 2,
+      "measured_delta": {
+        "distance": 0.29800812069472205,
+        "dx": 0.29800000000000004,
+        "dy": 0.002200000000000202,
+        "heading_change_degrees": -1.2141000000000304
+      }
+    },
+    {
+      "status": "no_path_progress",
+      "passed": false,
+      "action": "forward",
+      "path_progress_distance": -0.03339904023227098,
+      "expected_target_heading_degrees": 155.63635563086268,
+      "movement_vector_heading_degrees": 0.4670748123137969,
+      "heading_progress": true,
+      "min_progress_distance": 0.06,
+      "min_heading_change_degrees": 0,
+      "command_index": 3,
+      "measured_delta": {
+        "distance": 0.03680122280577139,
+        "dx": 0.03680000000000039,
+        "dy": 0.0002999999999997449,
+        "heading_change_degrees": 0
+      }
+    }
+  ],
+  "completion_status": {
+    "complete": false,
+    "target_index": 1,
+    "distance_to_target": 0.11708479833009915,
+    "waypoint_distances": [
+      {
+        "index": 0,
+        "distance": 0.850130489983744,
+        "segment_projections": [
+          {
+            "segment_index": 0,
+            "target_index": 1,
+            "progress": 1.1488930581613501,
+            "clamped_progress": 1,
+            "distance_to_segment": 0.11708479833009915
+          }
+        ]
+      },
+      {
+        "index": 1,
+        "distance": 0.11708479833009915,
+        "segment_projections": [
+          {
+            "segment_index": 0,
+            "target_index": 1,
+            "progress": 1.1488930581613501,
+            "clamped_progress": 1,
+            "distance_to_segment": 0.11708479833009915
+          }
+        ]
+      }
+    ],
+    "reason": "target_remaining"
+  },
+  "stop_reason": "no_target_progress",
+  "linear_execution_mode": "fixed_budget",
+  "effective_linear_ceiling": 3,
+  "linear_distance_ceiling": 1.478065248898031
+}

--- a/docs/night-go-card-beta54-20260814.md
+++ b/docs/night-go-card-beta54-20260814.md
@@ -39,7 +39,7 @@ bearing (9.2578°), so it did not recognize that the settled target was behind
 the mower. This is the identified cause of the unnecessary third pulse; it is
 not evidence that the mower or RTK failed.
 
-The current uncommitted follow-up changes only the night branch to derive its
+The PR #14 follow-up changes only the night branch to derive its
 residual target bearing from the settled post-pulse RTK position. That lets the
 existing night reverse-recovery refusal stop after an overshoot. The shared
 progress diagnostic and the VIO and legacy paths are unchanged. The card and

--- a/docs/night-go-card-beta54-20260814.md
+++ b/docs/night-go-card-beta54-20260814.md
@@ -1,0 +1,59 @@
+# Beta54 card-driven Night Go — supervised characterization
+
+**Date:** 2026-08-14
+**Build exercised:** `0.6.4-beta54`
+**Disposition:** safe stop, useful characterization, not an accuracy acceptance
+
+The operator explicitly authorized one supervised Night Go from `(4.954,
+-2.643)` to `(5.692, -2.602)`. The requested leg was 0.739138 m. The mower was
+in an open mapped area with its blades off. The complete card result is
+preserved unchanged as
+`docs/evidence-night-go-card-beta54-20260814T180345Z.json` (copied from the card
+download
+`mammotion-real-go-lawn-mower-back-yard-clip-skywalker-2026-08-14T18-03-45-242Z.json`).
+
+## Measured facts
+
+- The result used `turn_mode: "night"`, RTK `Fix`, angular speed 500, 200 ms
+  motion refresh, an 8° heading tolerance, three maximum linear commands, and
+  a 0.08 m waypoint tolerance.
+- The opening target heading was 86.9575°. Three turn commands
+  (`-500`, `-500`, `+500`) ended at `toward` 90.3537°, 3.3962° from the target.
+- Three forward commands were sent. Distances remaining after them were
+  0.225639, 0.082661, and 0.117085 m.
+- Pulse 2 therefore settled 0.002661 m outside the configured tolerance. Pulse
+  3 moved 0.036801 m and increased the target distance by 0.034423 m.
+- The executor stopped with `no_target_progress`. The final position was
+  `(5.8041, -2.6358)`, with RTK `Fix`, `MODE_READY`, blades off, and all recorded
+  stop operations successful.
+- The beta54 card omitted `sample_delays`, so the backend defaulted to
+  `[0, 5, 10, 20, 30, 45, 60]` after each command. That made the run take about
+  6.5 minutes even though all three turn-heading updates were visible within
+  three seconds.
+
+## Inference and off-mower follow-up
+
+The second pulse had already crossed the target. The night-only continuation
+decision nevertheless reused the shared progress diagnostic's pre-pulse target
+bearing (9.2578°), so it did not recognize that the settled target was behind
+the mower. This is the identified cause of the unnecessary third pulse; it is
+not evidence that the mower or RTK failed.
+
+The current uncommitted follow-up changes only the night branch to derive its
+residual target bearing from the settled post-pulse RTK position. That lets the
+existing night reverse-recovery refusal stop after an overshoot. The shared
+progress diagnostic and the VIO and legacy paths are unchanged. The card and
+harness also set `sample_delays: [0, 3]`, based on the observed heading-update
+window, to avoid the minute-long diagnostic waits.
+
+The follow-up tree now also contains a VIO-only Real Go throughput fix. It was
+verified locally with **668 pytest tests** and **46 frontend tests**. Ruff check,
+Ruff format check, mypy, and all pre-commit hooks also passed. These changes
+have not yet been committed, released, deployed, or tested on the mower.
+
+## What this run does not establish
+
+This single landing does not establish a supported night tolerance or an
+accuracy distribution. It also does not validate the follow-up controller
+change on hardware. Any further movement requires a new, explicit, supervised
+authorization.

--- a/docs/night-segment-implementation-plan-v1-20260813.md
+++ b/docs/night-segment-implementation-plan-v1-20260813.md
@@ -10,7 +10,7 @@
 night branch was deployed beginning with beta50. Beta54 later added a separate
 guarded Night Go card control. One beta54 card-driven run exposed a stale
 pre-pulse-bearing continuation decision; the night-only follow-up is verified,
-uncommitted, and deployed motion-disabled. The same tree includes a separate
+committed on draft PR #14, and deployed motion-disabled. The same branch includes a separate
 VIO-only Real Go throughput optimization. Its corrected supervised 0.70 m run
 reached the target in 19.2 s with 0.093100 m landing error, after every bounded
 post-feedback queue settle reached depth zero. Current verification: 668 pytest,

--- a/docs/night-segment-implementation-plan-v1-20260813.md
+++ b/docs/night-segment-implementation-plan-v1-20260813.md
@@ -6,13 +6,18 @@
 
 # Night segment — implementation plan (v1)
 
-**Status:** off-mower items 1–14 and on-mower items 15–18 complete; beta52
-deployed on 2026-08-13. Post-item-18 verification: 664 pytest, 39 frontend, and
-ruff/format/mypy/pre-commit green. Item 17 settled `toward` as body heading
-under reverse; see `docs/night-reverse-heading-20260813.md`. Item 18 completed
-as characterization, not a landing-accuracy acceptance pass; see
-`docs/night-segment-item18-20260814.md`. Written originally against `HEAD = d6a59f78` /
-deployed `0.6.4-beta49`.
+**Status:** off-mower items 1–14 and on-mower items 15–18 complete; the original
+night branch was deployed beginning with beta50. Beta54 later added a separate
+guarded Night Go card control. One beta54 card-driven run exposed a stale
+pre-pulse-bearing continuation decision; the night-only follow-up is verified,
+uncommitted, and deployed motion-disabled. The same tree includes a separate
+VIO-only Real Go throughput optimization. Its corrected supervised 0.70 m run
+reached the target in 19.2 s with 0.093100 m landing error, after every bounded
+post-feedback queue settle reached depth zero. Current verification: 668 pytest,
+46 frontend, and ruff/format/mypy/pre-commit green. See
+`docs/night-go-card-beta54-20260814.md` and
+`docs/real-go-throughput-hardware-20260814.md`. Written originally against
+`HEAD = d6a59f78` / deployed `0.6.4-beta49`.
 
 Every file/line anchor in this document was read at `d6a59f78` during authoring. Where a claim is inferred rather than read, it says so.
 
@@ -137,7 +142,8 @@ _NIGHT_TURN_ANGULAR_SPEED = 500
 #: max 3) at ~0.34-0.49 m per measured pulse, so >1.0 m is reach night does not
 #: have. It also bounds the lateral excursion from the containment-validated
 #: line: at the profile's 18 deg heading tolerance, 1.0 * sin(18) = 0.31 m.
-#: CHOSEN, not measured. No night segment has ever run.
+#: HISTORICAL AUTHORING NOTE: CHOSEN, not measured. At the time no night segment
+#: had run; items 15/18 and the later beta54 card run now provide measurements.
 _NIGHT_MAX_SEGMENT_LENGTH_M = 1.0
 
 #: Minimum measured pulse displacement before night will CLAIM an aim error.
@@ -700,6 +706,23 @@ New file `tests/components/mammotion/test_night_turn_mode.py` unless noted.
     `docs/evidence-night-segment-item18-20260814T000022Z.json`.
 19. **[on-mower, optional, DAYLIGHT REQUIRED]** A single daylight VIO segment as a belt-and-braces regression check. **Not owed** — no `LUBA_ACCEPTANCE_PROFILE` key changes value, so no Gate 5 re-run and no §4 re-pinning is obligated, and tests 9–15 cover it. Listed only so nobody assumes it was forgotten.
 
+### Post-v1 addendum — beta54 card run, 2026-08-14
+
+Beta54 exposed the contained night branch as a separate card control without
+changing `LUBA_ACCEPTANCE_PROFILE`. Its first supervised card run requested
+0.739138 m, reached heading tolerance after three turns, and stopped safely at
+0.117085 m after three forward pulses. Pulse 2 had settled at 0.082661 m; the
+shared diagnostic's pre-pulse target bearing was then reused by the night
+continuation check after the target had moved behind the mower.
+
+The verified local follow-up scopes the correction to night mode: compute the
+residual bearing from settled post-pulse RTK, then let the existing
+reverse-recovery refusal stop the overshoot. It also pins Night Go and the
+harness to `sample_delays: [0, 3]`, replacing beta54's inherited
+`[0, 5, 10, 20, 30, 45, 60]`. VIO, legacy, the shared progress diagnostic, and
+the frozen profile values remain unchanged. This addendum records later work;
+it does not alter the v1 design/refutation ledger or item-18 evidence.
+
 ### Follow-ups, explicitly not in v1
 
 - **`legacy`'s two latent defects** (no refresh forwarded, angular 180) — a live defect on the shipped Nudge path. Own review. Do not lose it.
@@ -717,7 +740,7 @@ New file `tests/components/mammotion/test_night_turn_mode.py` unless noted.
 | Turn quantum and rate through the **night branch** (angular 500, refresh 200, 1500 ms, `max_turn_commands` 4) | **Measured once: 54.2208°, 0.07459 m translation. More samples are still needed before fitting a distribution or correction floor.** | **No** |
 | `toward` latency during rotation | **Measured once: stepwise after the pulse, with no intermediate value at ~0.1 s cadence. More samples would be needed for a universal latency bound.** | **No** |
 | `toward` under one commanded **backward** pulse | **Measured: body heading stayed fixed; reverse course matched its opposite within 0.593779°. RapidState stayed `NO_POSE` and was non-informative.** | **No** |
-| Night landing accuracy, from task 18 | **One 0.70 m characterization landed 0.114277 m away on `no_target_progress`; insufficient for any tolerance or population claim.** | **No** |
+| Night landing accuracy | **Item 18 landed 0.114277 m away; the later beta54 card run landed 0.117085 m away after an unnecessary crossed-target pulse. Two characterizations remain insufficient for any tolerance or population claim.** | **No** |
 | Nothing | the v1 code in §3 | — |
 
 Everything in §3 is writable today. The only thing that needs daylight at all is the optional VIO regression run (task 19), and it is optional.

--- a/docs/night-toward-latency-20260813.md
+++ b/docs/night-toward-latency-20260813.md
@@ -40,9 +40,12 @@ stop to report arrival must not be claimed from the local request timestamps.
 This result does not explain away item 15's 81.416° forward-course mismatch:
 the segment executor already waits for post-command feedback before its forward
 phase. The body-heading versus course-over-ground question therefore remains
-open. Do not proceed to item 18. Plan item 17 (one backward pulse plus
-`RapidState.fuse_status`) is the next hardware discriminator and requires a new
-explicit supervised-motion authorization.
+open. **Historical next-step instruction:** at the time, do not proceed to item
+18. Item 17 and item 18 were subsequently completed; see
+`night-reverse-heading-20260813.md` and
+`night-segment-item18-20260814.md`. The original next step was item 17 (one
+backward pulse plus `RapidState.fuse_status`), which required a new explicit
+supervised-motion authorization.
 
 ## Same-day autonomous control comparison
 

--- a/docs/p0-beta-release.md
+++ b/docs/p0-beta-release.md
@@ -896,12 +896,17 @@ finished or that no defect remains. Three things are open and documented:
   (`docs/cross-track-is-set-at-the-start-of-the-leg-20260812.md`). Two candidate
   remedies were proposed and **refuted the same afternoon** — do not tune the
   control law on n = 2.
-- **Night is contained, not card-accepted.** An explicit RTK-only night branch
-  now exists for one forward-only segment. Item 18 reached its 8° opening-turn
-  tolerance and stopped safely at 0.114277 m on `no_target_progress`; this is
-  characterization, not a night landing-tolerance claim. The accepted card
-  profile remains the daylight VIO path and is byte-identical. See
-  `docs/night-segment-item18-20260814.md`.
+- **Night is contained and separately exposed, not accepted navigation.** An
+  explicit RTK-only night branch exists for one forward-only segment. Beta54
+  added a distinct guarded Night Go card control without changing the accepted
+  daylight VIO profile. Item 18 stopped at 0.114277 m; the first card-driven
+  run stopped at 0.117085 m and exposed a stale pre-pulse-bearing continuation
+  decision. The night-only correction is verified and deployed motion-disabled,
+  but is not yet released. The same tree's Real Go throughput correction passed
+  one supervised 0.70 m run at 0.093100 m landing error. See
+  `docs/night-segment-item18-20260814.md`,
+  `docs/night-go-card-beta54-20260814.md`, and
+  `docs/real-go-throughput-hardware-20260814.md`.
 - **BLE reliability is a hint, not a number** — see criterion 2.
 
 **Release** remains gated on its own criteria: non-LUBA hardware characterised

--- a/docs/real-go-throughput-hardware-20260814.md
+++ b/docs/real-go-throughput-hardware-20260814.md
@@ -1,0 +1,94 @@
+# Real Go throughput hardware check — 2026-08-14
+
+This record separates the measured first run from the correction inferred from
+it. The raw per-command service response is
+`docs/evidence-beta32-4segment-20260814T202705Z.json`.
+
+## Measured first run
+
+- Authorized path: `(5.0068, -3.0411)` to `(4.5118, -3.5361)`, requested
+  distance 0.700036 m, `turn_mode: "vio"`.
+- The mower began `MODE_READY`, RTK Fix, inside Backyard Right, with blades
+  off. The opening heading was already within tolerance, so no turn command was
+  sent.
+- One VIO calibration drive and one linear pulse succeeded. The linear pulse
+  sent six 200 ms refresh writes over 1294.161 ms, stopped successfully, and
+  obtained settled position feedback after 2.030 s / two polls.
+- The settled position `(4.7140, -3.3575)` was 0.269783 m from the target.
+- The second linear attempt was refused before dispatch in 0.064 ms with
+  `RuntimeError: BLE link is not ready for motion:
+  command_queue_backlogged`. No second linear movement write was sent.
+- The executor returned `command_failed`; the harness returned
+  `segment_failed`. It disarmed in `finally`. Independent readback showed
+  `real_motion_allowed: false`, no active session, `MODE_READY`, RTK Fix, and
+  blades off.
+
+This is a safe failure, not a landing result. The measured 0.269783 m residual
+is where the safety gate stopped the run after one successful forward pulse.
+
+## Inference and correction
+
+Reusing settled telemetry successfully removed the blind post-pulse three-second
+sample delay, but the report requests used to settle position could still be in
+the BLE command queue when the next movement was attempted. The immediate
+`command_queue_backlogged` refusal is evidence for that queue timing; it is not
+evidence that the BLE link disconnected.
+
+The local correction runs the existing bounded BLE queue-settle check after VIO
+position feedback. It returns immediately when the queue is empty, polls only
+the existing transient backlog/paused states, never overrides another liveness
+failure, and refuses the next command as
+`ble_link_not_ready_after_feedback` if the queue does not drain. Each result
+records `post_feedback_queue_settle`. Night and legacy branches are unchanged.
+
+Off-mower verification after the correction personally produced 668 pytest
+passes and 46 frontend passes. Ruff check, Ruff format check, mypy, and all nine
+pre-commit hooks passed.
+
+## Corrected motion-disabled deployment
+
+The corrected tree was deployed to the Home Assistant host and restarted with
+experimental motion disabled.
+
+- Backup: `/config/mammotion-backup-20260814-pre-queue-settle.tgz`
+- Deployment archive SHA-256:
+  `ec46d8fb0fce6aefcf7b2032c88a17b0693cf14cdd5bce086fb9396da5674b5d`
+- Deployed `services.py` MD5: `d6ab89ff4e4286b33d4fa5755bba5b0d`
+- Card MD5 at both serving paths: `4846aa9b6f9e0eefe67cb95f8326c3ba`
+- Manifest MD5: `ef8d5273c8e9730bc964579efb63116a`
+- HA API returned after 30 s; 132 Mammotion entities were present after 116 s.
+- Container `pymammotion`: `0.8.12.post1`.
+- Post-restart gate: disabled, `real_motion_allowed: false`, no active session,
+  `MODE_READY`.
+
+Read-only preflight then measured RTK Fix at `(4.7113, -3.3620)`, inside
+Backyard Right, BLE RSSI −64 dBm, VIO Light with 80 tracked features, mower
+ready, and blades off. A dry run proposed the next 0.70 m path from
+`(4.711, -3.362)` to `(4.216, -3.857)`, with an approximately 2° opening turn.
+That preview sent no movement and grants no authorization for another run.
+
+## Corrected supervised run
+
+The operator separately authorized the previewed path. The complete per-command
+response is `docs/evidence-beta32-4segment-20260814T204300Z.json`.
+
+- Executed path: `(4.7113, -3.3620)` toward `(4.2163, -3.8570)`, 0.70 m.
+- Result: `target_reached` in 19.2 s; one segment passed with 0.093100 m landing
+  error against the accepted 0.15 m tolerance.
+- Commands: one VIO calibration drive, zero turns, and three forward pulses.
+  All movement commands and all mandatory stops succeeded.
+- The three forward pulses sent 6 / 2 / 1 refresh writes and moved 0.358613 /
+  0.104511 / 0.073792 m respectively.
+- Each settled-position record replaced the requested `[0, 3]` sample waits.
+  Each new `post_feedback_queue_settle` record was live with queue depth zero,
+  completing in 101.225 / 100.702 / 100.242 ms. No backlog refusal occurred.
+- Final telemetry: `(4.2954, -3.8079)`, `MODE_READY`, RTK Fix, inside Backyard
+  Right, BLE −64 dBm, and blades off.
+- The harness disarmed in `finally`. Independent readback confirmed experimental
+  motion disabled, `real_motion_allowed: false`, no active session, and
+  `MODE_READY`.
+
+Measured conclusion: the bounded queue-settle correction prevents the specific
+immediate second-pulse backlog seen in the first run while preserving the
+standing safety gate. This single pass validates the correction on this path;
+it is not a statistical latency or reliability population.

--- a/scripts/beta32_validation_run.py
+++ b/scripts/beta32_validation_run.py
@@ -136,6 +136,10 @@ NIGHT_SEGMENT_PROFILE: dict[str, Any] = {
     "turn_pulse_duration_ms": 1500,
     "max_turn_translation_distance": 0.30,
     "ble_auto_recover": False,
+    # Measured 2026-08-14: every night-turn `toward` update arrived within
+    # three seconds. Omitting this inherited the backend's 60-second diagnostic
+    # window after every command and stretched six bounded pulses to ~6.5 min.
+    "sample_delays": [0, 3],
 }
 
 #: Hard preflight gates. Each is a (label, predicate, detail) triple evaluated

--- a/tests/components/mammotion/test_map_task_visibility.py
+++ b/tests/components/mammotion/test_map_task_visibility.py
@@ -4700,6 +4700,27 @@ async def test_night_refuses_reverse_recovery_after_pulse(
 
 
 @pytest.mark.asyncio
+async def test_night_refuses_forward_after_pulse_passes_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The residual bearing catches the beta54 third-pulse overshoot.
+
+    Measured 2026-08-14: pulse 2 crossed the waypoint and settled only 2.66 mm
+    outside tolerance. The old night check reused the PRE-pulse bearing, called
+    the correctly aimed pulse safe, then sent another forward write away from
+    the now-behind target. Replaying that geometry must invoke the existing
+    reverse-recovery refusal before another command can be considered.
+    """
+    result = await _run_one_night_linear_pulse(
+        monkeypatch, after_position=(1.883, 1.0, 90.13)
+    )
+    assert result["stop_reason"] == "target_requires_reverse_recovery"
+    assert result["linear_commands_sent"] == 1
+    assert result["night_aim"][-1]["bearing_to_target_degrees"] == pytest.approx(180.0)
+    assert result["night_aim"][-1]["decision"] == "reverse_recovery_required"
+
+
+@pytest.mark.asyncio
 async def test_night_does_not_claim_aim_below_baseline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -7651,9 +7672,14 @@ async def test_vio_segment_calibration_drive_computes_offset(
     async def no_sleep(_: float) -> None:
         return None
 
+    refresh_settle_seconds: list[float] = []
+
     async def fake_refresh(
         coordinator_arg: MammotionReportUpdateCoordinator,
+        *,
+        settle_seconds: float = 2.0,
     ) -> dict:
+        refresh_settle_seconds.append(settle_seconds)
         # Simulate the post-drive feedback refresh: mower moved +x/+y and the
         # motion woke VIO with a fresh body heading.
         coordinator.data.mowing_state.pos_x += 0.03
@@ -7676,6 +7702,7 @@ async def test_vio_segment_calibration_drive_computes_offset(
     # Motion vector (+0.06, +0.06) -> 45 deg map heading; offset = 45 - 15 = 30.
     assert result["map_motion_heading_degrees"] == pytest.approx(45.0)
     assert result["offset_degrees"] == pytest.approx(30.0)
+    assert refresh_settle_seconds == [0.0, 0.0]
     coordinator.async_stop_manual_motion.assert_awaited()
 
 
@@ -7692,6 +7719,8 @@ async def test_vio_segment_calibration_drive_rejects_offset_on_degraded_feed(
 
     async def fake_refresh(
         coordinator_arg: MammotionReportUpdateCoordinator,
+        *,
+        settle_seconds: float = 2.0,
     ) -> dict:
         # Motion moved the mower, but VIO woke blind: vio_state latched active
         # with 0 tracked features, so the vision heading is untrustworthy and the
@@ -7714,6 +7743,133 @@ async def test_vio_segment_calibration_drive_rejects_offset_on_degraded_feed(
     assert result["reason"] == "vio_feed_degraded"
     assert result["offset_degrees"] is None
     assert result["vio_feed"]["live"] is False
+
+
+@pytest.mark.asyncio
+async def test_vio_linear_pulse_reuses_settled_position_without_sample_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real Go does not wait through samples after position already settled."""
+    coordinator = _pulse_coordinator(position=(1.0, 1.0, 0.0))
+    coordinator.data.report_data.vision_info = SimpleNamespace(
+        heading=0.0, vio_state=2, track_feature_num=100, brightness=100
+    )
+    sleep_delays: list[float] = []
+    refresh_settle_seconds: list[float] = []
+    queue_settles: list[int] = []
+    queue_live = {"value": True}
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    async def fake_turn(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {
+            "stop_reason": "target_heading_reached",
+            "commands_sent": 0,
+            "command_results": [],
+        }
+
+    async def fake_refresh(
+        *_args: object, settle_seconds: float = 2.0, **_kwargs: object
+    ) -> dict[str, object]:
+        refresh_settle_seconds.append(settle_seconds)
+        return {"ok": True, "settle_seconds": settle_seconds}
+
+    async def fake_motion_refresh(
+        *_args: object, **_kwargs: object
+    ) -> dict[str, object]:
+        return {
+            "refresh_enabled": True,
+            "refresh_interval_ms": 200,
+            "refresh_commands_sent": 1,
+        }
+
+    async def fake_settle(*_args: object, **_kwargs: object) -> dict[str, object]:
+        coordinator.data.mowing_state.pos_x = 1.45
+        telemetry = _custom_path_telemetry_snapshot(coordinator)
+        return {
+            "telemetry": telemetry,
+            "settled": True,
+            "moved": True,
+            "feed_stale": False,
+            "settle_polls": 2,
+            "wait_seconds": 2.0,
+        }
+
+    async def fake_queue_settle(*_args: object) -> dict[str, object]:
+        queue_settles.append(1)
+        return {
+            "live": queue_live["value"],
+            "reason": None if queue_live["value"] else "command_queue_backlogged",
+            "queue_depth": 0 if queue_live["value"] else 1,
+        }
+
+    monkeypatch.setattr(mammotion_services.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(mammotion_services, "_vio_turn_to_heading_staged", fake_turn)
+    monkeypatch.setattr(
+        mammotion_services, "_refresh_position_after_raw_motion", fake_refresh
+    )
+    monkeypatch.setattr(
+        mammotion_services, "_motion_refresh_window", fake_motion_refresh
+    )
+    monkeypatch.setattr(mammotion_services, "_settle_linear_position_feed", fake_settle)
+    monkeypatch.setattr(
+        mammotion_services, "_settle_ble_command_queue", fake_queue_settle
+    )
+
+    result = await _raw_pymammotion_execute_vector_segment(
+        coordinator,
+        [{"x": 1.0, "y": 1.0}, {"x": 1.5, "y": 1.0}],
+        dry_run=False,
+        confirm_blades_off=True,
+        confirm_clear_area=True,
+        turn_mode="vio",
+        vio_heading_offset_degrees=0.0,
+        max_linear_commands=1,
+        motion_refresh_interval_ms=200,
+        sample_delays=(0, 3),
+    )
+
+    assert result["stop_reason"] == "target_reached"
+    assert refresh_settle_seconds == [0.0]
+    assert sleep_delays == []
+    # One settle at executor entry, one after report-driven position settling.
+    assert queue_settles == [1, 1]
+    linear = next(
+        command
+        for command in result["command_results"]
+        if command.get("phase") == "linear_forward_to_target"
+    )
+    assert linear["post_settle_feedback"] == {
+        "source": "position_settle",
+        "additional_wait_seconds": 0.0,
+        "requested_sample_delays_skipped": [0, 3],
+    }
+    assert linear["post_feedback_queue_settle"]["live"] is True
+    assert result["samples"][-1]["source"] == "position_settle"
+    assert result["samples"][-1]["telemetry"]["position"]["x"] == pytest.approx(1.45)
+
+    # A persistent queue is named and refused before a second pulse, rather
+    # than surfacing as the hardware run's generic command_failed.
+    coordinator.data.mowing_state.pos_x = 1.0
+    queue_live["value"] = False
+    blocked = await _raw_pymammotion_execute_vector_segment(
+        coordinator,
+        [{"x": 1.0, "y": 1.0}, {"x": 1.8, "y": 1.0}],
+        dry_run=False,
+        confirm_blades_off=True,
+        confirm_clear_area=True,
+        turn_mode="vio",
+        vio_heading_offset_degrees=0.0,
+        max_linear_commands=2,
+        motion_refresh_interval_ms=200,
+        sample_delays=(0, 3),
+    )
+    assert blocked["stop_reason"] == "ble_link_not_ready_after_feedback"
+    assert blocked["linear_commands_sent"] == 1
+    assert blocked["post_feedback_queue_settle"]["reason"] == (
+        "command_queue_backlogged"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/frontend/mammotion-custom-path-card.test.mjs
+++ b/tests/frontend/mammotion-custom-path-card.test.mjs
@@ -104,6 +104,7 @@ test("Night Go has a separate frozen fixed-budget profile", () => {
     ble_auto_recover: false,
     night_angular_speed: 500,
     toward_mirror_degrees: 90.13,
+    sample_delays: [0, 3],
   });
   assert.equal(LUBA_ACCEPTANCE_PROFILE.turn_mode, "vio");
   assert.equal(LUBA_ACCEPTANCE_PROFILE.heading_tolerance_degrees, 18);
@@ -126,6 +127,7 @@ test("Night Go emits one backend vector segment and leaves Real Go unchanged", (
   assert.equal(night.payload.heading_tolerance_degrees, 8);
   assert.equal(night.payload.max_linear_commands, 3);
   assert.equal(night.payload.motion_refresh_interval_ms, 200);
+  assert.deepEqual(night.payload.sample_delays, [0, 3]);
   assert.equal("max_linear_pulse_ceiling" in night.payload, false);
   assert.equal(night.payload.confirm_blades_off, true);
   assert.equal(night.payload.confirm_clear_area, true);
@@ -699,6 +701,31 @@ test("fresh preflight is fetched and confirmations reset after failure", async (
   assert.equal(element._confirmBladesOff, false);
   assert.equal(element._confirmClearArea, false);
   assert.match(element._status, /failed/);
+});
+
+test("successful Real Go reloads runtime once before and once after execution", async () => {
+  const element = card();
+  element._waypoints = [{ x: 2, y: 2 }];
+  element._confirmBladesOff = true;
+  element._confirmClearArea = true;
+  let runtimeLoads = 0;
+  element._loadRuntimeState = async () => {
+    runtimeLoads += 1;
+  };
+  element._validateAndPreview = async () => {};
+  element._callService = async () => ({
+    stop_reason: "target_reached",
+    completion_status: { complete: true },
+  });
+  element._startRunTicker = () => {};
+  element._stopRunTicker = () => {};
+  element._persistLastRun = () => {};
+  element._saveRunToHistory = () => {};
+
+  await element._runRealGo();
+
+  assert.equal(runtimeLoads, 2);
+  assert.match(element._status, /Real Go complete/);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/scripts/test_beta32_validation_run.py
+++ b/tests/scripts/test_beta32_validation_run.py
@@ -106,6 +106,7 @@ def test_item18_profile_pins_the_planned_fixed_envelope() -> None:
         "turn_pulse_duration_ms": 1500,
         "max_turn_translation_distance": 0.30,
         "ble_auto_recover": False,
+        "sample_delays": [0, 3],
     }
 
 


### PR DESCRIPTION
## Summary

- correct Night Go continuation to recompute the residual bearing from settled post-pulse RTK position
- bound Night Go diagnostic sampling to `[0, 3]` without changing any frozen `LUBA_ACCEPTANCE_PROFILE` value
- reduce additive Real Go feedback waits, reuse settled telemetry, and explicitly drain/refuse a backlogged BLE command queue before the next pulse
- remove one duplicate successful Real Go runtime reload
- add regression tests, complete per-command hardware evidence, and reconciled handoff/release documentation

## Root cause and measured result

The beta54 Night Go run reused a pre-pulse target bearing after crossing the waypoint and sent an unnecessary third pulse. The first optimized Real Go run then exposed that report requests used by position settling could remain in the shared BLE queue; the standing motion gate safely refused the next pulse with `command_queue_backlogged`.

The correction uses the existing bounded BLE queue-settle check after VIO feedback and never overrides a persistent liveness failure. A separately authorized 0.70 m hardware run subsequently reached `target_reached` in 19.2 seconds with 0.093100 m landing error. All movement commands and mandatory stops succeeded; each post-feedback queue record reached depth zero in about 100–101 ms. The gate was independently verified disabled afterward.

## Invariants reviewed

- `LUBA_ACCEPTANCE_PROFILE` block is byte-identical to beta54
- legacy turn branch is byte-identical to beta54
- all nine original `turn_mode == "vio"` safety/control blocks remain intact
- no `vio_active` construction changed
- Real Go card payload remains sourced from the frozen profile
- Night and legacy feedback timing is unchanged; new response provenance is VIO-only

## Verification

- pytest: 668 passed, 50% coverage
- frontend: 46 passed
- Ruff check: passed
- Ruff format: 58 files already formatted
- mypy: no issues in 28 source files
- pre-commit: all 9 hooks passed

The complete raw evidence is committed separately before its prose analysis.